### PR TITLE
Update bundle to fix error on bundle install on OS X Yosemite

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ gem 'logstasher', '0.4.8'
 gem 'sass-rails', '3.2.6'
 
 group :assets do
-  gem "therubyracer", "0.11.4"
+  gem "therubyracer", "~> 0.12.0"
   gem 'uglifier'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,7 +132,7 @@ GEM
     kramdown (0.13.8)
     launchy (2.1.0)
       addressable (~> 2.2.6)
-    libv8 (3.11.8.17)
+    libv8 (3.16.14.7)
     libwebsocket (0.1.7.1)
       addressable
       websocket
@@ -268,8 +268,8 @@ GEM
       tilt (~> 1.1, != 1.3.0)
     state_machine (1.2.0)
     statsd-ruby (1.0.0)
-    therubyracer (0.11.4)
-      libv8 (~> 3.11.8.12)
+    therubyracer (0.12.2)
+      libv8 (~> 3.16.14.0)
       ref
     thor (0.19.1)
     tilt (1.4.1)
@@ -337,7 +337,7 @@ DEPENDENCIES
   simplecov-rcov (= 0.2.3)
   state_machine (= 1.2.0)
   statsd-ruby (= 1.0.0)
-  therubyracer (= 0.11.4)
+  therubyracer (~> 0.12.0)
   timecop (= 0.5.9.2)
   uglifier
   unicorn (= 4.3.1)


### PR DESCRIPTION
I was seeing the following error when running `bundle install`:

    Unable to find a compiler officially supported by v8.
    It is recommended to use GCC v4.4 or higher
    Using compiler: g++

This then seems to have resulted in the following compilation error:

    ../src/cached-powers.cc:136:18: error: unused variable 'kCachedPowersLength' [-Werror,-Wunused-const-variable]
    static const int kCachedPowersLength = ARRAY_SIZE(kCachedPowers);
                     ^
I believe the problem was [fixed][1] between version 3.16.14.3 and version
3.16.14.7 of `libv8`. Relaxing the Gemfile constraint on `therubyracer` and
bundle updating `therubyracer` & `libv8` seems to have done the trick.

See also a [similar fix][2] for the `static` app.

[1]: https://github.com/cowboyd/libv8/pull/124
[2]: https://github.com/alphagov/static/pull/570