### PR TITLE
Bump GDS API adapters to 20.1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'govuk_admin_template', '2.3.1'
 gem 'formtastic', '2.3.0'
 gem 'formtastic-bootstrap', '3.0.0'
 
-gem 'gds-api-adapters', '10.13.0'
+gem 'gds-api-adapters', '20.1.1'
 gem 'statsd-ruby', '1.0.0', :require => 'statsd'
 
 if ENV['BUNDLE_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,8 @@ GEM
       nokogiri (>= 1.5.0)
     database_cleaner (1.0.1)
     diff-lcs (1.1.3)
+    domain_name (0.5.24)
+      unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     eventmachine (1.0.0)
     execjs (1.4.0)
@@ -89,12 +91,13 @@ GEM
       actionpack (>= 3.0)
     formtastic-bootstrap (3.0.0)
       formtastic (>= 2.2)
-    gds-api-adapters (10.13.0)
+    gds-api-adapters (20.1.1)
       link_header
       lrucache (~> 0.1.1)
       null_logger
       plek
-      rest-client (~> 1.6.3)
+      rack-cache
+      rest-client (~> 1.8.0)
     gds-sso (9.3.0)
       multi_json (~> 1.0)
       oauth2 (~> 1.0)
@@ -118,6 +121,8 @@ GEM
     hashie (3.2.0)
     hike (1.2.3)
     htmlentities (4.3.1)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
     http_parser.rb (0.5.3)
     i18n (0.7.0)
     inherited_resources (1.3.0)
@@ -168,6 +173,7 @@ GEM
     multi_json (1.11.1)
     multi_xml (0.5.5)
     multipart-post (1.2.0)
+    netrc (0.10.3)
     nokogiri (1.5.5)
     null_logger (0.0.1)
     oauth2 (1.0.0)
@@ -229,8 +235,10 @@ GEM
       redis (~> 3.0.4)
     ref (1.0.5)
     responders (0.6.4)
-    rest-client (1.6.7)
-      mime-types (>= 1.16)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
     rubyzip (0.9.9)
     sanitize (2.0.3)
       nokogiri (>= 1.4.4, < 1.6)
@@ -286,6 +294,9 @@ GEM
     uglifier (1.3.0)
       execjs (>= 0.3.0)
       multi_json (~> 1.0, >= 1.0.2)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.1)
     unicorn (4.3.1)
       kgio (~> 2.6)
       rack
@@ -318,7 +329,7 @@ DEPENDENCIES
   factory_girl_rails
   formtastic (= 2.3.0)
   formtastic-bootstrap (= 3.0.0)
-  gds-api-adapters (= 10.13.0)
+  gds-api-adapters (= 20.1.1)
   gds-sso (= 9.3.0)
   govspeak (~> 1.2)
   govuk_admin_template (= 2.3.1)


### PR DESCRIPTION
This changes the user agent to include the app
name in API requests.

https://trello.com/c/qkHdtob4/247-bump-gds-api-adapters-everywhere-it-s-used-to-include-user-agent-information