### PR TITLE
Add a startup script

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+bundle install
+bundle exec rails s -p 3002


### PR DESCRIPTION
As seen in: other apps.

Handy for running this app separately from `bowler` without having
to remember the port, which is what I was doing.