### PR TITLE
Gss codes for areas

### DIFF
--- a/app/presenters/areas_presenter.rb
+++ b/app/presenters/areas_presenter.rb
@@ -35,7 +35,10 @@ class AreasPresenter
       "slug" => area["name"].parameterize,
       "name" => area["name"],
       "country_name" => area["country_name"],
-      "type" => area["type"]
+      "type" => area["type"],
+      "codes" => {
+        "gss"  => area.fetch("codes", {})["gss"],
+      },
     }
   end
 

--- a/test/unit/presenters/areas_presenter_test.rb
+++ b/test/unit/presenters/areas_presenter_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 require 'areas_presenter'
 
 class AreasPresenterTest < ActiveSupport::TestCase
-  context "presenting an areas by type mapit response" do
+  context "presenting a mapit response" do
     setup do
       bridge = OpenStruct.new(:payload => {
         :code => 200,
@@ -47,67 +47,6 @@ class AreasPresenterTest < ActiveSupport::TestCase
         assert_equal "E09000033", @result["codes"]["gss"]
 
         refute @result.has_key?("parent_area")
-      end
-    end
-
-    context "second result" do
-      setup do
-        @result = @presenter.present["results"][1]
-      end
-
-      should "expose the correct data" do
-        assert_equal "london", @result["slug"]
-        assert_equal "London", @result["name"]
-        assert_equal "England", @result["country_name"]
-        assert_equal "EUR", @result["type"]
-        assert_equal "E15000007", @result["codes"]["gss"]
-      end
-    end
-  end
-
-  context "presenting a postcode lookup mapit response" do
-    setup do
-      response = OpenStruct.new(:payload => {
-        :code => 200,
-        :areas => [
-          {
-            "id" => 123,
-            "name" => "Westminster City Council",
-            "country_name" => "England",
-            "type" => "LBO",
-            "codes" => {
-              "gss" => "E09000033",
-            },
-          },
-          {
-            "id" => 234,
-            "name" => "London",
-            "country_name" => "England",
-            "type" => "EUR",
-            "codes" => {
-              "gss" => "E15000007",
-            },
-          },
-        ],
-      })
-      @presenter = AreasPresenter.new(response)
-    end
-
-    should "format the correct response status" do
-      assert_equal "ok", @presenter.present["_response_info"]["status"]
-    end
-
-    context "first result" do
-      setup do
-        @result = @presenter.present["results"].first
-      end
-
-      should "expose the correct data" do
-        assert_equal "westminster-city-council", @result["slug"]
-        assert_equal "Westminster City Council", @result["name"]
-        assert_equal "England", @result["country_name"]
-        assert_equal "LBO", @result["type"]
-        assert_equal "E09000033", @result["codes"]["gss"]
       end
     end
 

--- a/test/unit/presenters/areas_presenter_test.rb
+++ b/test/unit/presenters/areas_presenter_test.rb
@@ -6,50 +6,107 @@ class AreasPresenterTest < ActiveSupport::TestCase
     setup do
       bridge = OpenStruct.new(:payload => {
         :code => 200,
-        :areas => [ { "id" => 123, "name" => "Westminster City Council", "country_name" => "England", "type" => "LBO" },
-                    { "id" => 234, "name" => "London", "country_name" => "England", "type" => "EUR" } ]
+        :areas => [
+          {
+            "id" => 123,
+            "name" => "Westminster City Council",
+            "country_name" => "England",
+            "type" => "LBO",
+          },
+          {
+            "id" => 234,
+            "name" => "London",
+            "country_name" => "England",
+            "type" => "EUR",
+          },
+        ],
       })
       @presenter = AreasPresenter.new(bridge)
     end
+
     should "format the correct response status" do
       assert_equal "ok", @presenter.present["_response_info"]["status"]
     end
-    should "expose the correct data" do
-      assert_equal "westminster-city-council", @presenter.present["results"].first["slug"]
-      assert_equal "Westminster City Council", @presenter.present["results"].first["name"]
-      assert_equal "England", @presenter.present["results"].first["country_name"]
-      assert_equal "LBO", @presenter.present["results"].first["type"]
-      assert_equal "london", @presenter.present["results"].last["slug"]
-      assert_equal "London", @presenter.present["results"].last["name"]
-      assert_equal "England", @presenter.present["results"].last["country_name"]
-      assert_equal "EUR", @presenter.present["results"].last["type"]
 
-      refute @presenter.present["results"].first.has_key?("parent_area")
+    context "first result" do
+      setup do
+        @result = @presenter.present["results"].first
+      end
+
+      should "expose the correct data" do
+        assert_equal "westminster-city-council", @result["slug"]
+        assert_equal "Westminster City Council", @result["name"]
+        assert_equal "England", @result["country_name"]
+        assert_equal "LBO", @result["type"]
+
+        refute @result.has_key?("parent_area")
+      end
+    end
+
+    context "second result" do
+      setup do
+        @result = @presenter.present["results"][1]
+      end
+
+      should "expose the correct data" do
+        assert_equal "london", @result["slug"]
+        assert_equal "London", @result["name"]
+        assert_equal "England", @result["country_name"]
+        assert_equal "EUR", @result["type"]
+      end
     end
   end
+
   context "presenting a postcode lookup mapit response" do
     setup do
       response = OpenStruct.new(:payload => {
         :code => 200,
         :areas => [
-          { "id" => 123, "name" => "Westminster City Council", "country_name" => "England", "type" => "LBO" },
-          { "id" => 234, "name" => "London", "country_name" => "England", "type" => "EUR" }
-        ]
+          {
+            "id" => 123,
+            "name" => "Westminster City Council",
+            "country_name" => "England",
+            "type" => "LBO",
+          },
+          {
+            "id" => 234,
+            "name" => "London",
+            "country_name" => "England",
+            "type" => "EUR",
+          },
+        ],
       })
       @presenter = AreasPresenter.new(response)
     end
+
     should "format the correct response status" do
       assert_equal "ok", @presenter.present["_response_info"]["status"]
     end
-    should "expose the correct data" do
-      assert_equal "westminster-city-council", @presenter.present["results"].first["slug"]
-      assert_equal "Westminster City Council", @presenter.present["results"].first["name"]
-      assert_equal "England", @presenter.present["results"].first["country_name"]
-      assert_equal "LBO", @presenter.present["results"].first["type"]
-      assert_equal "london", @presenter.present["results"].last["slug"]
-      assert_equal "London", @presenter.present["results"].last["name"]
-      assert_equal "England", @presenter.present["results"].last["country_name"]
-      assert_equal "EUR", @presenter.present["results"].last["type"]
+
+    context "first result" do
+      setup do
+        @result = @presenter.present["results"].first
+      end
+
+      should "expose the correct data" do
+        assert_equal "westminster-city-council", @result["slug"]
+        assert_equal "Westminster City Council", @result["name"]
+        assert_equal "England", @result["country_name"]
+        assert_equal "LBO", @result["type"]
+      end
+    end
+
+    context "second result" do
+      setup do
+        @result = @presenter.present["results"][1]
+      end
+
+      should "expose the correct data" do
+        assert_equal "london", @result["slug"]
+        assert_equal "London", @result["name"]
+        assert_equal "England", @result["country_name"]
+        assert_equal "EUR", @result["type"]
+      end
     end
   end
 end

--- a/test/unit/presenters/areas_presenter_test.rb
+++ b/test/unit/presenters/areas_presenter_test.rb
@@ -12,12 +12,18 @@ class AreasPresenterTest < ActiveSupport::TestCase
             "name" => "Westminster City Council",
             "country_name" => "England",
             "type" => "LBO",
+            "codes" => {
+              "gss" => "E09000033",
+            },
           },
           {
             "id" => 234,
             "name" => "London",
             "country_name" => "England",
             "type" => "EUR",
+            "codes" => {
+              "gss" => "E15000007",
+            },
           },
         ],
       })
@@ -38,6 +44,7 @@ class AreasPresenterTest < ActiveSupport::TestCase
         assert_equal "Westminster City Council", @result["name"]
         assert_equal "England", @result["country_name"]
         assert_equal "LBO", @result["type"]
+        assert_equal "E09000033", @result["codes"]["gss"]
 
         refute @result.has_key?("parent_area")
       end
@@ -53,6 +60,7 @@ class AreasPresenterTest < ActiveSupport::TestCase
         assert_equal "London", @result["name"]
         assert_equal "England", @result["country_name"]
         assert_equal "EUR", @result["type"]
+        assert_equal "E15000007", @result["codes"]["gss"]
       end
     end
   end
@@ -67,12 +75,18 @@ class AreasPresenterTest < ActiveSupport::TestCase
             "name" => "Westminster City Council",
             "country_name" => "England",
             "type" => "LBO",
+            "codes" => {
+              "gss" => "E09000033",
+            },
           },
           {
             "id" => 234,
             "name" => "London",
             "country_name" => "England",
             "type" => "EUR",
+            "codes" => {
+              "gss" => "E15000007",
+            },
           },
         ],
       })
@@ -93,6 +107,7 @@ class AreasPresenterTest < ActiveSupport::TestCase
         assert_equal "Westminster City Council", @result["name"]
         assert_equal "England", @result["country_name"]
         assert_equal "LBO", @result["type"]
+        assert_equal "E09000033", @result["codes"]["gss"]
       end
     end
 
@@ -106,6 +121,7 @@ class AreasPresenterTest < ActiveSupport::TestCase
         assert_equal "London", @result["name"]
         assert_equal "England", @result["country_name"]
         assert_equal "EUR", @result["type"]
+        assert_equal "E15000007", @result["codes"]["gss"]
       end
     end
   end


### PR DESCRIPTION
Publisher and Business Support Finder fetch their area data from Imminence.

They currently use the areas' slugified names for publishing and then finding a Business Support Scheme.

Since area names are subject to change over time, we're migrating Business Support to use the more stable GSS code for an area instead.

It'd be good to hear whether we're presenting this new field at the correct level of nesting. We receive "gss" from MapIt (along with various other codes) nested under "codes". Since we don't currently present any of these codes, I've just flattened it and presented "gss" alongside "name" and the like.