### PR TITLE
Bump govuk_admin_template to 3.0.0 for GA fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem "mongoid_rails_migrations", "1.0.0"
 
 gem 'airbrake', '~> 4.1.0'
 
-gem 'govuk_admin_template', '2.3.1'
+gem 'govuk_admin_template', '3.0.0'
 gem 'formtastic', '2.3.0'
 gem 'formtastic-bootstrap', '3.0.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,15 +34,15 @@ GEM
       builder
       multi_json
     arel (3.0.3)
-    autoprefixer-rails (5.2.0.1)
+    autoprefixer-rails (6.0.3)
       execjs
       json
     bootstrap-kaminari-views (0.0.3)
       kaminari (>= 0.13)
       rails (>= 3.1)
-    bootstrap-sass (3.3.5)
+    bootstrap-sass (3.3.5.1)
       autoprefixer-rails (>= 5.0.0.1)
-      sass (>= 3.2.19)
+      sass (>= 3.3.0)
     builder (3.0.4)
     capybara (1.1.2)
       mime-types (>= 1.16)
@@ -114,7 +114,7 @@ GEM
       htmlentities (~> 4)
       kramdown (~> 0.13.3)
       sanitize (= 2.0.3)
-    govuk_admin_template (2.3.1)
+    govuk_admin_template (3.0.0)
       bootstrap-sass (~> 3.3.3)
       jquery-rails (~> 3.1.3)
       rails (>= 3.2.0)
@@ -130,7 +130,7 @@ GEM
       has_scope (~> 0.5.0)
       responders (~> 0.6.0)
     journey (1.0.4)
-    jquery-rails (3.1.3)
+    jquery-rails (3.1.4)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
     json (1.8.3)
@@ -339,7 +339,7 @@ DEPENDENCIES
   gds-api-adapters (= 20.1.1)
   gds-sso (= 9.3.0)
   govspeak (~> 1.2)
-  govuk_admin_template (= 2.3.1)
+  govuk_admin_template (= 3.0.0)
   inherited_resources
   kaminari (= 0.14.1)
   launchy


### PR DESCRIPTION
Trello: https://trello.com/c/1dS5tgTg/125-fix-analytics-in-all-16-admin-tools

Ensures the Analytics domain is set to the 
`GOVUK_APP_DOMAIN` env variable rather than 
being hardcoded.