### PR TITLE
Setup ci-reporter for jenkins correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ log/*.log
 tmp/
 coverage
 test/reports
+features/reports

--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,7 @@
 require File.expand_path('../config/application', __FILE__)
 if Rails.env.development? || Rails.env.test?
   require 'ci/reporter/rake/minitest'
+  require 'ci/reporter/rake/test_unit'
 end
 
 Imminence::Application.load_tasks

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -10,4 +10,6 @@ fi
 
 bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
 bundle exec rake db:drop
-bundle exec rake ci:setup:minitest default
+# We only need one of the minitest or testunit setup tasks, but we'll fix it
+# when we jump to rails 4.x and decide which one it is
+bundle exec rake ci:setup:minitest ci:setup:testunit default


### PR DESCRIPTION
Now that we have to include testunit and minitest the app seems to think it's
using testunit not minitest so the ci:setup:minitest task doesn't end up
generating the report files.  This means that our build won't pass as a lack of
reports is a considered a failure by ci.

We also add the ci:setup:cucumber step so that we get reports from the features.
This requires a change to the ci build to look at, but it doesn't hurt.

Once we're on rails 4.x we can review again which framework we are using for tests; minitest vs. test-unit and only invoke one of the setup tasks.