### PR TITLE
Autocorrect mistakes in postcodes entered into local transaction pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,8 @@ gem 'inherited_resources', '~> 1.6.0'
 gem 'kaminari', '~> 0.16.0'
 gem 'bootstrap-kaminari-views', '~> 0.0.3'
 
+gem 'uk_postcode', '2.1.0'
+
 gem 'sidekiq', '~> 2.16'
 
 gem 'state_machines-mongoid', '~> 0.1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -315,6 +315,7 @@ GEM
     uglifier (2.7.2)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
+    uk_postcode (2.1.0)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.1)
@@ -373,6 +374,7 @@ DEPENDENCIES
   state_machines-mongoid (~> 0.1.1)
   statsd-ruby (= 1.0.0)
   uglifier (= 2.7.2)
+  uk_postcode (= 2.1.0)
   unicorn (= 4.3.1)
   webmock (~> 1.11)
 

--- a/app/controllers/areas_controller.rb
+++ b/app/controllers/areas_controller.rb
@@ -18,7 +18,11 @@ class AreasController < ApplicationController
   end
 
   def search
-    api_response = Imminence.mapit_api.location_for_postcode(params[:postcode])
+    # Strip trailing whitespace, most non-alphanumerics, and use the
+    # uk_postcode gem to potentially transpose O/0 and I/1.
+    sanitized_postcode = UKPostcode.parse(params[:postcode].gsub(/[^\w\s]/i, '').strip).to_s
+
+    api_response = Imminence.mapit_api.location_for_postcode(sanitized_postcode)
     response = MapitApi::AreasByPostcodeResponse.new(api_response)
     @presenter = AreasPresenter.new(response)
 

--- a/app/controllers/areas_controller.rb
+++ b/app/controllers/areas_controller.rb
@@ -1,4 +1,5 @@
 require 'mapit_api'
+require 'postcode_sanitizer'
 
 class AreasController < ApplicationController
   def index
@@ -18,11 +19,7 @@ class AreasController < ApplicationController
   end
 
   def search
-    # Strip trailing whitespace, most non-alphanumerics, and use the
-    # uk_postcode gem to potentially transpose O/0 and I/1.
-    sanitized_postcode = UKPostcode.parse(params[:postcode].gsub(/[^\w\s]/i, '').strip).to_s
-
-    api_response = Imminence.mapit_api.location_for_postcode(sanitized_postcode)
+    api_response = Imminence.mapit_api.location_for_postcode(PostcodeSanitizer.sanitize(params[:postcode]))
     response = MapitApi::AreasByPostcodeResponse.new(api_response)
     @presenter = AreasPresenter.new(response)
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
   end
 
   get '/areas/:area_type', :to => 'areas#index', :constraints => { :area_type => /EUR|CTY|DIS|LBO|LGD|MTD|UTA/ }
-  get '/areas/:postcode', :to => 'areas#search', :constraints => { :postcode => /[\w% ]+/ }
+  get '/areas/:postcode', :to => 'areas#search'
 
   resources :places, :only => :show
   root :to => redirect('/admin')

--- a/lib/postcode_sanitizer.rb
+++ b/lib/postcode_sanitizer.rb
@@ -1,0 +1,7 @@
+class PostcodeSanitizer
+  def self.sanitize(postcode)
+    # Strip trailing whitespace, non-alphanumerics, and use the
+    # uk_postcode gem to potentially transpose O/0 and I/1.
+    UKPostcode.parse(postcode.gsub(/[^a-z0-9 ]/i, '').strip).to_s
+  end
+end

--- a/test/functional/areas_controller_test.rb
+++ b/test/functional/areas_controller_test.rb
@@ -36,4 +36,21 @@ class AreasControllerTest < ActionController::TestCase
       get :index, { area_type: 'FOO' }
     end
   end
+
+  test "typos in postcodes are silently corrected" do
+    # This is what the postcode searched for should be transformed to.
+    Imminence.mapit_api.stubs(:location_for_postcode).with("WC2B 6NH")
+    MapitApi::AreasByPostcodeResponse.any_instance.stubs(:payload).returns(
+      :code => 200,
+      :areas => []
+    )
+
+    get :search, { :postcode => "WC2B-6NH] ", :format => :json }
+
+    assert_equal 200, response.status
+
+    response_hash = assigns(:presenter).present
+
+    assert_equal "ok", response_hash["_response_info"]["status"]
+  end
 end

--- a/test/unit/lib/postcode_sanitizer_test.rb
+++ b/test/unit/lib/postcode_sanitizer_test.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+
+class PostcodeSanitizerTest < ActiveSupport::TestCase
+
+  context "postcodes come through to imminence" do
+
+    should "strip trailing spaces from entered postcodes" do
+      assert_equal "WC2B 6NH", PostcodeSanitizer.sanitize("WC2B 6NH ")
+    end
+
+    should "strip non-alphanumerics from entered postcodes" do
+      assert_equal "WC2B 6NH", PostcodeSanitizer.sanitize("WC2B   -6NH]")
+    end
+
+    should "transpose O/0 and I/1 if necessary" do
+      # Thanks to the uk_postcode gem.
+      assert_equal "W1A 0AA", PostcodeSanitizer.sanitize("WIA OAA")
+    end
+
+  end
+
+end


### PR DESCRIPTION
- We were seeing lots of errors for postcodes entered
  with obvious typos, eg. hyphens instead of spaces, 0 instead of O, I
  instead of 1, etc, so this is an attempt at fixing most common ones.
- Strip most non-alphanumerics and trailing whitespace. Also use the
  `uk_postcode` gem to fix transposition of I/1, O/0.
- The `routes.rb` file had a constraint on the `areas/postcode` route,
  but this change failed to work with it, so I've removed it in favour
  of a better regex in the controller.

Trello: https://trello.com/c/2KHTEa4l/127-auto-correct-mistakes-in-postcodes-entered-by-users-on-local-transaction-pages.

(Thanks to @h-lame for help with understanding the tests.)