### PR TITLE
Using sidekiq-statsd gem to plot sidekiq activity

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,10 +15,10 @@ gem 'formtastic', '~> 3.1.2'
 gem 'formtastic-bootstrap', '~> 3.1.1'
 
 gem 'gds-api-adapters', '~> 24.5.0'
-gem 'statsd-ruby', '1.0.0', :require => 'statsd'
+gem 'statsd-ruby', '1.1.0', require: 'statsd'
 
 if ENV['BUNDLE_DEV']
-  gem 'gds-sso', :path => '../gds-sso'
+  gem 'gds-sso', path: '../gds-sso'
 else
   gem 'gds-sso', '~> 11.0.0'
 end
@@ -29,6 +29,7 @@ gem 'kaminari', '~> 0.16.0'
 gem 'bootstrap-kaminari-views', '~> 0.0.3'
 
 gem 'sidekiq', '~> 2.16'
+gem 'sidekiq-statsd', '0.1.5'
 
 gem 'state_machines-mongoid', '~> 0.1.1'
 gem 'logstasher', '0.4.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -284,6 +284,10 @@ GEM
       json
       redis (~> 3.1)
       redis-namespace (~> 1.3)
+    sidekiq-statsd (0.1.5)
+      activesupport
+      sidekiq (>= 2.6)
+      statsd-ruby (>= 1.1.0)
     simplecov (0.10.0)
       docile (~> 1.1.0)
       json (~> 1.8)
@@ -305,7 +309,7 @@ GEM
     state_machines-mongoid (0.1.1)
       mongoid (>= 4.0.0)
       state_machines-activemodel
-    statsd-ruby (1.0.0)
+    statsd-ruby (1.1.0)
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.1)
@@ -368,10 +372,11 @@ DEPENDENCIES
   sdoc (~> 0.4.0)
   shoulda-context
   sidekiq (~> 2.16)
+  sidekiq-statsd (= 0.1.5)
   simplecov (~> 0.10.0)
   simplecov-rcov (~> 0.2.3)
   state_machines-mongoid (~> 0.1.1)
-  statsd-ruby (= 1.0.0)
+  statsd-ruby (= 1.1.0)
   uglifier (= 2.7.2)
   unicorn (= 4.3.1)
   webmock (~> 1.11)

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -4,6 +4,10 @@ redis_config = YAML.load_file(Rails.root.join("config", "redis.yml"))[Rails.env]
 
 Sidekiq.configure_server do |config|
   config.redis = redis_config
+
+  config.server_middleware do |chain|
+    chain.add Sidekiq::Statsd::ServerMiddleware, env: 'govuk.app.imminence', prefix: 'workers'
+  end
 end
 
 Sidekiq.configure_client do |config|


### PR DESCRIPTION
In order to improve tracking of what's going on with Sidekiq workers, add `sidekiq-statsd` gem and configuration.

Part of https://trello.com/c/z2aHqwS8/48-add-sidekiq-statsd-to-apps-that-use-sidekiq