### PR TITLE
Include all place fields in dataset CSV export

### DIFF
--- a/app/controllers/places_controller.rb
+++ b/app/controllers/places_controller.rb
@@ -51,11 +51,7 @@ class PlacesController < ApplicationController
       @places = data_set.places
     end
 
-    # For some reason, Rails isn't picking up that we want to use the CSV
-    # renderer to render CSV files.
-    respond_with(@places) do |format|
-      format.csv { render csv: @places }
-    end
+    respond_with(@places)
   end
 
   protected

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -191,14 +191,14 @@ class Place
     return base_parameters.merge(location_parameters)
   end
 
-  private
+  def override_lat_lng?
+    override_lat.present? and override_lng.present?
+  end
+
+private
 
   def clear_location
     self.location = nil
-  end
-
-  def override_lat_lng?
-    override_lat.present? and override_lng.present?
   end
 
   def has_both_lat_lng_overrides

--- a/app/presenters/data_set_csv_presenter.rb
+++ b/app/presenters/data_set_csv_presenter.rb
@@ -17,28 +17,48 @@ class DataSetCsvPresenter
 
   def to_array_for_csv
     [].tap do |csv|
-      # We need to handle the location fields separately from the others.
-      # location is a Point object (so doesn't serialize well to CSV by default)
-      # and doesn't need to be exported because it's either overridden from the
-      # override fields or set from MapIt's data using the postcode.
-      # Also exclude the id from the CSV since it isn't needed by the import.
-
-      # The fields called 'lng' and 'lat' are used as the override values by
-      # Place.parameters_from_hash so we need to name them accordingly in the
-      # CSV to avoid them being lost if a CSV is exported and then imported.
-      non_location_headers = Place.attribute_names - ['_id', 'location', 'override_lng', 'override_lat']
-      location_headers = ['lng', 'lat']
-      csv << (non_location_headers + location_headers)
+      csv << all_headers
       places.each do |place|
-        row = non_location_headers.collect { |h| place.send(h.to_sym) }
-        if place.override_lat_lng?
-          row << place.override_lng
-          row << place.override_lat
-        else
-          2.times { |n| row << nil }
-        end
-        csv << row
+        csv << build_row(place)
       end
+    end
+  end
+
+private
+
+  # We need to handle the location fields separately from the others.
+  # location is a Point object (so doesn't serialize well to CSV by default)
+  # and doesn't need to be exported because it's either overridden from the
+  # override fields or set from MapIt's data using the postcode.
+  # Also exclude the id from the CSV since it isn't needed by the import.
+  def non_location_headers
+    @non_location_headers ||= Place.attribute_names - ['_id', 'location', 'override_lng', 'override_lat']
+  end
+
+  # The fields called 'lng' and 'lat' are used as the override values by
+  # Place.parameters_from_hash so we need to name them accordingly in the
+  # CSV to avoid them being lost if a CSV is exported and then imported.
+  def location_headers
+    ['lng', 'lat']
+  end
+
+  def all_headers
+    non_location_headers + location_headers
+  end
+
+  def build_row(place)
+    non_location_fields(place) + location_fields(place)
+  end
+
+  def non_location_fields(place)
+    non_location_headers.map { |header| place.send(header.to_sym) }
+  end
+
+  def location_fields(place)
+    if place.override_lat_lng?
+      [place.override_lng, place.override_lat]
+    else
+      [nil, nil]
     end
   end
 end

--- a/app/presenters/data_set_csv_presenter.rb
+++ b/app/presenters/data_set_csv_presenter.rb
@@ -17,10 +17,27 @@ class DataSetCsvPresenter
 
   def to_array_for_csv
     [].tap do |csv|
-      headers = ['name', 'address1', 'address2', 'town', 'postcode', 'access_notes', 'general_notes', 'url', 'lat', 'lng', 'phone', 'fax', 'text_phone']
-      csv << headers
+      # We need to handle the location fields separately from the others.
+      # location is a Point object (so doesn't serialize well to CSV by default)
+      # and doesn't need to be exported because it's either overridden from the
+      # override fields or set from MapIt's data using the postcode.
+      # Also exclude the id from the CSV since it isn't needed by the import.
+
+      # The fields called 'lng' and 'lat' are used as the override values by
+      # Place.parameters_from_hash so we need to name them accordingly in the
+      # CSV to avoid them being lost if a CSV is exported and then imported.
+      non_location_headers = Place.attribute_names - ['_id', 'location', 'override_lng', 'override_lat']
+      location_headers = ['lng', 'lat']
+      csv << (non_location_headers + location_headers)
       places.each do |place|
-        csv << headers.collect { |h| place.send(h.to_sym) }
+        row = non_location_headers.collect { |h| place.send(h.to_sym) }
+        if place.override_lat_lng?
+          row << place.override_lng
+          row << place.override_lat
+        else
+          2.times { |n| row << nil }
+        end
+        csv << row
       end
     end
   end

--- a/app/views/admin/data_sets/_file_help.html.erb
+++ b/app/views/admin/data_sets/_file_help.html.erb
@@ -1,12 +1,15 @@
-<p class="lead normal">The data file must:</p>
+<p class="lead normal">The CSV file must:</p>
 <ul class="lead normal">
   <li>include row headers</li>
   <li>use headers matching the specified format – ie “address1”, not “Address 1”</li>
   <li>provide at minimum a postcode for identifying locations</li>
 </ul>
 <p class="lead normal">
-It can include the columns:
+These columns will be imported (any others will be ignored):
 </p>
 <blockquote>
-  <strong>name</strong> | <strong>address1</strong> | <strong>address2</strong> | <strong>town</strong> | <strong>postcode</strong> | <strong>access_notes</strong> | <strong>general_notes</strong> | <strong>url</strong> | <strong>email</strong> | <strong>phone</strong> | <strong>fax</strong> | <strong>text_phone</strong> | <strong>source_address</strong> | <strong>snac</strong>
+  <strong>name</strong> | <strong>source_address</strong> | <strong>address1</strong> | <strong>address2</strong> | <strong>town</strong> | <strong>postcode</strong> | <strong>access_notes</strong> | <strong>general_notes</strong> | <strong>url</strong> | <strong>email</strong> | <strong>phone</strong> | <strong>fax</strong> | <strong>text_phone</strong> | <strong>snac</strong> | <strong>lng</strong> | <strong>lat</strong>
 </blockquote>
+<p class="lead normal">
+Use <strong>lng</strong> and <strong>lat</strong> to override the location for a place instead of using the postcode's location.
+</p>

--- a/config/initializers/formtastic.rb
+++ b/config/initializers/formtastic.rb
@@ -1,10 +1,10 @@
 # encoding: utf-8
 
 # --------------------------------------------------------------------------------------------------
-# Please note: If you're subclassing Formtastic::SemanticFormBuilder in a Rails 3 project, 
-# Formtastic uses class_attribute for these configuration attributes instead of the deprecated 
-# class_inheritable_attribute. The behaviour is slightly different with subclasses (especially 
-# around attributes with Hash or Array) values, so make sure you understand what's happening. 
+# Please note: If you're subclassing Formtastic::SemanticFormBuilder in a Rails 3 project,
+# Formtastic uses class_attribute for these configuration attributes instead of the deprecated
+# class_inheritable_attribute. The behaviour is slightly different with subclasses (especially
+# around attributes with Hash or Array) values, so make sure you understand what's happening.
 # See the documentation for class_attribute in ActiveSupport for more information.
 # --------------------------------------------------------------------------------------------------
 

--- a/db/migrate/20130111144306_change_permissions_to_array.rb
+++ b/db/migrate/20130111144306_change_permissions_to_array.rb
@@ -5,7 +5,7 @@ class ChangePermissionsToArray < Mongoid::Migration
 
     field "permissions"
 
-    # Migrations should be independent of the app, so we need this class, but 
+    # Migrations should be independent of the app, so we need this class, but
     # it was defaulting the collection_name to the migration's class name.
     def self.collection_name
       "users"

--- a/features/data_sets.feature
+++ b/features/data_sets.feature
@@ -140,3 +140,12 @@ Feature: Managing data sets
       And I go to the page for the "Register Offices" service
 
     Then I should see an indication that my data set is empty
+
+  Scenario: Exporting a data set to CSV and uploading it again
+    Given I have previously created the "Council tax valuation offices" service
+
+    When I export the latest "Council tax valuation offices" data set to CSV
+      And I upload the exported CSV to the "Council tax valuation offices" service
+
+    Then the "Council tax valuation offices" service should have two data sets
+      And the places should be identical between the datasets in the "Council tax valuation offices" service

--- a/features/step_definitions/data_set_steps.rb
+++ b/features/step_definitions/data_set_steps.rb
@@ -91,6 +91,18 @@ When /^I update the name to be "(.*?)"$/ do |name|
   fill_in_place_form_with(name)
 end
 
+When /^I export the latest "(.*?)" data set to CSV$/ do |name|
+  visit path_for_latest_data_set_for_service(name)
+  click_link 'CSV'
+  @exported_csv_data = page.source
+end
+
+When /^I upload the exported CSV to the "(.*?)" service$/ do |name|
+  visit path_for_service(name)
+  upload_csv_data(@exported_csv_data)
+  run_all_delayed_jobs
+end
+
 Then /^I should see an indication that my file wasn't accepted$/ do
   assert page.has_content?("Could not process CSV file. Please check the format.")
 end
@@ -145,6 +157,10 @@ Then /^there should still just be one data set$/ do
   assert_equal 1, Service.first.data_sets.count
 end
 
+Then /^the "(.*?)" service should have two data sets$/ do |name|
+  assert_equal 2, Service.where(name: name).first.data_sets.count
+end
+
 Then /^there shouldn't be a "(.*?)" service$/ do |name|
   assert_equal 0, Service.where(name: name).count
 end
@@ -152,6 +168,21 @@ end
 Then /^there should be a place named "(.*?)"$/ do |name|
   within "table.table-places" do
     assert page.has_content?(name)
+  end
+end
+
+Then /^the places should be identical between the datasets in the "(.*?)" service$/ do |name|
+  service = Service.where(name: name).first
+  data_set_1 = service.data_sets.first
+  data_set_2 = service.data_sets.last
+  [data_set_1, data_set_2].each { |data_set| assert_equal 1, data_set.places.count }
+
+  place_1 = data_set_1.places.first
+  place_2 = data_set_2.places.first
+
+  expected_identical_attributes = Place.attribute_names - ['_id', 'data_set_version']
+  expected_identical_attributes.each do |attribute|
+    assert_equal place_1.send(attribute.to_sym), place_2.send(attribute.to_sym)
   end
 end
 

--- a/features/support/data/council-tax-valuation-offices.csv
+++ b/features/support/data/council-tax-valuation-offices.csv
@@ -1,0 +1,2 @@
+service_slug,data_set_version,name,source_address,address1,address2,town,postcode,access_notes,general_notes,url,email,phone,fax,text_phone,geocode_error,snac,lng,lat
+council-tax-valuation-offices,1,Fife Council,Fife House (03) North Street Glenrothes KY7 5LY,Fife House (03),North Street,Glenrothes,KY7 5LY,Access note,General note,www.example.com,fife@example.com,01592 414141,01592 413194,01592 413195,,00QR,-3.17575,56.19755

--- a/features/support/service_helper.rb
+++ b/features/support/service_helper.rb
@@ -65,6 +65,22 @@ module ServiceHelper
     click_button "Update Place"
   end
 
+  def upload_csv_data(csv_data)
+    csv_file = Tempfile.new('exported_data_set.csv')
+    begin
+      csv_file.write(csv_data)
+      csv_file.rewind
+
+      within "#new-data" do
+        attach_file "Data file", csv_file.path
+        click_button "Create Data set"
+      end
+    ensure
+      csv_file.close
+      csv_file.unlink
+    end
+  end
+
   def mapit_knows_nothing_about_any_postcodes
     stub_request(:get, %r{#{GdsApi::TestHelpers::Mapit::MAPIT_ENDPOINT}/postcode/[^\.]+\.json})
       .to_return(:body => { "code" => 404, "error" => "No Postcode matches the given query." }.to_json, :status => 404)

--- a/test/integration/admin/place_create_edit_test.rb
+++ b/test/integration/admin/place_create_edit_test.rb
@@ -12,12 +12,12 @@ class PlaceCreateEditTest < ActionDispatch::IntegrationTest
 
   test "Editing a place to override location coordinates" do
     visit "/admin/services/#{@service.to_param}/data_sets/#{@data_set.to_param}/places/#{@place.to_param}/edit"
-        
+
     fill_in "Override latitude", with: "54.9949"
     fill_in "Override longitude", with: "-1.4274"
 
     click_on "Update Place"
-    
+
     within('table.table-places') do
       assert page.has_css?("td", text: "54.9949, -1.4274")
     end
@@ -25,12 +25,12 @@ class PlaceCreateEditTest < ActionDispatch::IntegrationTest
 
   test "Editing a place to override location coordinates with gibberish" do
     visit "/admin/services/#{@service.to_param}/data_sets/#{@data_set.to_param}/places/#{@place.to_param}/edit"
-        
+
     fill_in "Override latitude", with: "Barry"
     fill_in "Override longitude", with: "Manilow"
 
     click_on "Update Place"
-    
+
     within("form#edit_place_#{@place.to_param}") do
       assert page.has_css?("div#place_override_lat_input", text: "is not a number")
       assert page.has_css?("div#place_override_lng_input", text: "is not a number")
@@ -39,11 +39,11 @@ class PlaceCreateEditTest < ActionDispatch::IntegrationTest
 
   test "Editing a place to override one location coordinate" do
     visit "/admin/services/#{@service.to_param}/data_sets/#{@data_set.to_param}/places/#{@place.to_param}/edit"
-        
+
     fill_in "Override latitude", with: "54.9949"
 
     click_on "Update Place"
-    
+
     within("form#edit_place_#{@place.to_param}") do
       assert page.has_css?("div#place_override_lng_input", text: "longitude must be a valid coordinate")
     end
@@ -53,7 +53,7 @@ class PlaceCreateEditTest < ActionDispatch::IntegrationTest
     visit "/admin/services/#{@service.to_param}/data_sets/#{@data_set.to_param}/places/#{@place.to_param}/edit"
 
     click_on "Update Place"
-    
+
     within('table.table-places') do
       assert page.has_css?("td", text: "53.1055, -2.0175")
     end

--- a/test/unit/file_verifier_test.rb
+++ b/test/unit/file_verifier_test.rb
@@ -11,7 +11,7 @@ class FileVerifierTest < ActiveSupport::TestCase
     f = Rails.root.join("features/support/data/register-offices.csv")
     assert_equal 'text/plain', Imminence::FileVerifier.new(f).mime_type
   end
-  
+
   test "it correctly identifies a PNG masquerading as a CSV" do
     f = Rails.root.join("features/support/data/rails.csv")
     assert_equal 'image/png', Imminence::FileVerifier.new(f).mime_type

--- a/test/unit/presenters/data_set_csv_presenter_test.rb
+++ b/test/unit/presenters/data_set_csv_presenter_test.rb
@@ -11,7 +11,10 @@ class DataSetCsvPresenterTest < ActiveSupport::TestCase
 
   def expected_header_row
     [
+      "service_slug",
+      "data_set_version",
       "name",
+      "source_address",
       "address1",
       "address2",
       "town",
@@ -19,11 +22,14 @@ class DataSetCsvPresenterTest < ActiveSupport::TestCase
       "access_notes",
       "general_notes",
       "url",
-      "lat",
-      "lng",
+      "email",
       "phone",
       "fax",
       "text_phone",
+      "geocode_error",
+      "snac",
+      "lng",
+      "lat",
     ]
   end
 
@@ -37,13 +43,17 @@ class DataSetCsvPresenterTest < ActiveSupport::TestCase
     setup do
       @place = FactoryGirl.create(:place, service_slug: @service.slug,
                                   data_set_version: @data_set.version,
+                                  email: "camden@example.com", snac: "00AG",
                                   override_lng: 0.0, override_lat: 1.0)
       @result = @presenter.to_array_for_csv
     end
 
     should "contain a header row and a results row" do
       expected_place_row = [
+        @service.slug,
+        @data_set.version,
         @place.name,
+        @place.source_address,
         @place.address1,
         @place.address2,
         @place.town,
@@ -51,11 +61,14 @@ class DataSetCsvPresenterTest < ActiveSupport::TestCase
         @place.access_notes,
         @place.general_notes,
         @place.url,
-        @place.override_lat,
-        @place.override_lng,
+        @place.email,
         @place.phone,
         @place.fax,
         @place.text_phone,
+        @place.geocode_error,
+        @place.snac,
+        @place.override_lng,
+        @place.override_lat,
       ]
       assert_equal 2, @result.size
       assert_equal expected_header_row, @result.first

--- a/test/unit/presenters/data_set_csv_presenter_test.rb
+++ b/test/unit/presenters/data_set_csv_presenter_test.rb
@@ -1,0 +1,65 @@
+require 'test_helper'
+require 'data_set_csv_presenter'
+
+class DataSetCsvPresenterTest < ActiveSupport::TestCase
+  setup do
+    @service = FactoryGirl.create(:service)
+    @data_set = @service.data_sets.create!
+    @presenter = DataSetCsvPresenter.new(@data_set)
+    @result = @presenter.to_array_for_csv
+  end
+
+  def expected_header_row
+    [
+      "name",
+      "address1",
+      "address2",
+      "town",
+      "postcode",
+      "access_notes",
+      "general_notes",
+      "url",
+      "lat",
+      "lng",
+      "phone",
+      "fax",
+      "text_phone",
+    ]
+  end
+
+  context "presenting an empty dataset" do
+    should "contain only a header row" do
+      assert_equal [expected_header_row], @result
+    end
+  end
+
+  context "presenting a dataset with a place" do
+    setup do
+      @place = FactoryGirl.create(:place, service_slug: @service.slug,
+                                  data_set_version: @data_set.version,
+                                  override_lng: 0.0, override_lat: 1.0)
+      @result = @presenter.to_array_for_csv
+    end
+
+    should "contain a header row and a results row" do
+      expected_place_row = [
+        @place.name,
+        @place.address1,
+        @place.address2,
+        @place.town,
+        @place.postcode,
+        @place.access_notes,
+        @place.general_notes,
+        @place.url,
+        @place.override_lat,
+        @place.override_lng,
+        @place.phone,
+        @place.fax,
+        @place.text_phone,
+      ]
+      assert_equal 2, @result.size
+      assert_equal expected_header_row, @result.first
+      assert_equal expected_place_row, @result.last
+    end
+  end
+end


### PR DESCRIPTION
We've seen instances of data loss in Production in the past because users export a CSV, edit it and upload it to create a new dataset version; not all fields were exported so some data was lost. When the service uses local authority lookup and the SNACs are lost, no results at all will be returned to users.

This workflow needs to be supported because it's often hard to find an individual place to edit in the app; in the longer term we should make that easier to do so that users don't need to replace the entire dataset to edit a single record. It's also useful to have all fields in the CSV so that users can find the records with geocode errors and fix them in the same place - those errors aren't displayed against individual records in the app.

This change includes all of the fields from the `Place` model in the CSV export, with some special handling (explained in commit messages) of some fields. It also adds a Cucumber scenario to test this workflow, and unit tests for the CSV presenter. It doesn't modify the import at all, but makes the exported fields work with the import.