### PR TITLE
Stop trying to reference removed models in migrations

### DIFF
--- a/db/migrate/20130426105110_fix_business_support_facet_duplication.rb
+++ b/db/migrate/20130426105110_fix_business_support_facet_duplication.rb
@@ -1,5 +1,7 @@
 class FixBusinessSupportFacetDuplication < Mongoid::Migration
   def self.up
+    return unless defined? BusinessSupportScheme
+
     BusinessSupportScheme.all.each do |scheme|
       scheme.business_types.uniq!
       scheme.locations.uniq!

--- a/db/migrate/20130618103949_add_delayed_job_indexes.rb
+++ b/db/migrate/20130618103949_add_delayed_job_indexes.rb
@@ -1,5 +1,6 @@
 class AddDelayedJobIndexes < Mongoid::Migration
   def self.up
+    return unless defined?(Delayed::Backend::Mongoid::Job)
     Delayed::Backend::Mongoid::Job.create_indexes
   end
 

--- a/db/migrate/20130905125225_introduce_business_size_facet.rb
+++ b/db/migrate/20130905125225_introduce_business_size_facet.rb
@@ -1,5 +1,7 @@
 class IntroduceBusinessSizeFacet < Mongoid::Migration
   def self.up
+    return unless defined?(BusinessSupportScheme)
+
     BusinessSupportScheme.all.each do |scheme|
       scheme.add_to_set(
         business_sizes: [

--- a/db/migrate/20131031141704_update_incorrect_business_size_facet.rb
+++ b/db/migrate/20131031141704_update_incorrect_business_size_facet.rb
@@ -1,5 +1,6 @@
 class UpdateIncorrectBusinessSizeFacet < Mongoid::Migration
   def self.up
+    return unless defined?(BusinessSupport) && defined?(BusinessSupport::BusinessSize)
     BusinessSupport::BusinessSize.where(name: "Between 501 and 1000").update(slug: "between-501-and-1000")
   end
 

--- a/db/migrate/20131031143134_update_incorrect_business_size_slugs.rb
+++ b/db/migrate/20131031143134_update_incorrect_business_size_slugs.rb
@@ -1,5 +1,7 @@
 class UpdateIncorrectBusinessSizeSlugs < Mongoid::Migration
   def self.up
+    return unless defined?(BusinessSupportScheme)
+
     BusinessSupportScheme.all.each do |bss|
       if bss[:business_sizes].include? 'between-501-and-100'
         bss.pull(:business_sizes, 'between-501-and-100')

--- a/db/migrate/20131101142717_remove_business_stage.rb
+++ b/db/migrate/20131101142717_remove_business_stage.rb
@@ -1,5 +1,7 @@
 class RemoveBusinessStage < Mongoid::Migration
   def self.up
+    return unless defined?(BusinessSupport) && defined?(BusinessSupport::Stage)
+
     BusinessSupport::Stage.where(slug: 'exiting-a-business').delete
   end
 

--- a/db/migrate/20131101142748_remove_business_stage_from_support_schemes.rb
+++ b/db/migrate/20131101142748_remove_business_stage_from_support_schemes.rb
@@ -1,5 +1,6 @@
 class RemoveBusinessStageFromSupportSchemes < Mongoid::Migration
   def self.up
+    return unless defined?(BusinessSupportScheme)
     BusinessSupportScheme.all.each {|bss| bss.pull(:stages, 'exiting-a-business') }
   end
 


### PR DESCRIPTION
So that I can run a db:create and db:migrate without failures