### PR TITLE
Fix Find My Nearest postcode error

### DIFF
--- a/app/controllers/places_controller.rb
+++ b/app/controllers/places_controller.rb
@@ -16,9 +16,8 @@ end
 class PlacesController < ApplicationController
   respond_to :json, :kml, :csv
 
-  rescue_from MapitApi::InvalidPostcodeError do
-    head 400
-  end
+  rescue_from MapitApi::InvalidPostcodeError, with: :error_400
+  rescue_from MapitApi::ValidPostcodeNoLocation, with: :error_400
 
   def show
     # Show a set of places in relation to a service
@@ -55,6 +54,10 @@ class PlacesController < ApplicationController
   end
 
 protected
+  def error_400(e)
+    error_message = e.message.gsub("MapitApi::", "").camelize(:lower)
+    render status: 400, json: { error: "#{error_message}" }
+  end
 
   def select_data_set(service, version = nil)
     if user_signed_in? && version.present?

--- a/lib/mapit_api.rb
+++ b/lib/mapit_api.rb
@@ -1,9 +1,11 @@
 module MapitApi
   class InvalidPostcodeError < StandardError; end
+  class ValidPostcodeNoLocation < StandardError; end
 
   def self.location_for_postcode(postcode)
     location_data = Imminence.mapit_api.location_for_postcode(postcode)
     raise InvalidPostcodeError if location_data.nil?
+    raise ValidPostcodeNoLocation if location_data.lat.nil? || location_data.lon.nil?
     location_data
   end
 

--- a/test/fixtures/mapit_responses/JE4_5TP.json
+++ b/test/fixtures/mapit_responses/JE4_5TP.json
@@ -1,0 +1,4 @@
+{
+    "areas": {},
+    "postcode": "JE4 5TP"
+}

--- a/test/functional/places_controller_test.rb
+++ b/test/functional/places_controller_test.rb
@@ -105,4 +105,16 @@ class PlacesControllerTest < ActionController::TestCase
       end
     end
   end
+
+  test "rescue from MapitApi::ValidPostcodeNoLocation" do
+    service = Service.create!(
+      name: "Number Plate Supplier",
+      slug: "number-plate-supplier"
+    )
+    stub_mapit_postcode_response_from_fixture("JE4 5TP")
+    get :show, id: service.slug, postcode: "JE4 5TP", format: :json
+
+    assert_response 400
+    assert_equal(JSON.parse(response.body)["error"], "validPostcodeNoLocation")
+  end
 end

--- a/test/unit/lib/mapit_api_test.rb
+++ b/test/unit/lib/mapit_api_test.rb
@@ -50,9 +50,15 @@ class MapitApiTest < ActiveSupport::TestCase
     should "raise InvalidPostcodeError for an invalid postcode" do
       GdsApi::Mapit.any_instance.expects(:location_for_postcode).returns(nil)
 
-      assert_raise MapitApi::InvalidPostcodeError do
-        MapitApi.district_snac_for_postcode("AB1 2CD")
-      end
+      assert_raises(MapitApi::InvalidPostcodeError) { MapitApi.district_snac_for_postcode("AB1 2CD") }
+    end
+  end
+
+  context "valid_post_code_no_location" do
+    should "raise ValidPostcodeNoLocation for a valid postcode with no location" do
+      stub_mapit_postcode_response_from_fixture("JE4 5TP")
+
+      assert_raises(MapitApi::ValidPostcodeNoLocation) { MapitApi.location_for_postcode("JE4 5TP") }
     end
   end
 


### PR DESCRIPTION
# Why
For Channel Island post codes the Mapit API was returning a result having found the postcode but would not have any data for required places inside the area. This resulted in a error being sent from Imminence to Frontend as shown below.

Frontend now shows a more helpful message stating that no results were found.

# Before:
![before](https://cloud.githubusercontent.com/assets/3466862/12783962/506c3a4e-ca7c-11e5-9afd-8e8b7b88ea68.png)


# After:
![after](https://cloud.githubusercontent.com/assets/3466862/12948121/f5cf0324-cff7-11e5-88fc-f577cdaaa5e5.png)


https://trello.com/c/TC6mZatW/265-imminence-errors-on-jersey-postcodes-for-find-my-nearests