### PR TITLE
Order LA place lookups by nearness to the user's postcode

### DIFF
--- a/app/models/data_set.rb
+++ b/app/models/data_set.rb
@@ -59,18 +59,16 @@ class DataSet
   end
 
   def places_for_postcode(postcode, distance = nil, limit = nil)
+    location_data = MapitApi.location_for_postcode(postcode)
+    location = Point.new(latitude: location_data.lat, longitude: location_data.lon)
     if service.location_match_type == 'local_authority'
-      snac = MapitApi.district_snac_for_postcode(postcode)
+      snac = MapitApi.extract_snac_from_mapit_response(location_data)
       if snac
-        location_data = MapitApi.location_for_postcode(postcode)
-        location = Point.new(latitude: location_data.lat, longitude: location_data.lon)
         places_near(location, distance, limit, snac)
       else
         []
       end
     else
-      location_data = MapitApi.location_for_postcode(postcode)
-      location = Point.new(latitude: location_data.lat, longitude: location_data.lon)
       places_near(location, distance, limit)
     end
   end

--- a/lib/mapit_api.rb
+++ b/lib/mapit_api.rb
@@ -17,8 +17,11 @@ module MapitApi
 
   def self.district_snac_for_postcode(postcode)
     location_data = location_for_postcode(postcode)
+    extract_snac_from_mapit_response(location_data)
+  end
 
-    district = location_data.areas.detect {|area| DISTRICT_TYPES.include?(area.type) }
+  def self.extract_snac_from_mapit_response(location_data)
+    district = location_data.areas.detect { |area| DISTRICT_TYPES.include?(area.type) }
     district.codes['ons'] if district
   end
 

--- a/test/integration/places_api_test.rb
+++ b/test/integration/places_api_test.rb
@@ -118,23 +118,29 @@ class PlacesAPITest < ActionDispatch::IntegrationTest
         @service = FactoryGirl.create(:service, location_match_type: 'local_authority')
         @place1 = FactoryGirl.create(:place, service_slug: @service.slug, snac: "18UK",
                   location: Point.new(latitude: 51.0519276, longitude: -4.1907002), name: "John's Of Appledore")
-        @place2 = FactoryGirl.create(:place, service_slug: @service.slug, snac: "00AG",
+        @place2 = FactoryGirl.create(:place, service_slug: @service.slug, snac: "18UK",
+                  location: Point.new(latitude: 51.053834, longitude: -4.191422), name: "Susie's Tea Rooms")
+        @place3 = FactoryGirl.create(:place, service_slug: @service.slug, snac: "00AG",
                   location: Point.new(latitude: 51.500728, longitude: -0.124626), name: "Palace of Westminster")
+        @place4 = FactoryGirl.create(:place, service_slug: @service.slug, snac: "00AG",
+                  location: Point.new(latitude: 51.51837458322272, longitude: -0.12133586354538765), name: "FreeState Coffee")
       end
 
-      should "return the place(s) for the authority corresponding to the postcode" do
+      should "return the place(s) for the authority corresponding to the postcode in order of nearness" do
         stub_mapit_postcode_response_from_fixture("EX39 1QS")
         stub_mapit_postcode_response_from_fixture("WC2B 6NH")
 
         get "/places/#{@service.slug}.json?postcode=EX39+1QS"
         data = JSON.parse(last_response.body)
-        assert_equal 1, data.length
-        assert_equal @place1.name, data[0]['name']
+        assert_equal 2, data.length
+        assert_equal @place2.name, data[0]['name']
+        assert_equal @place1.name, data[1]['name']
 
         get "/places/#{@service.slug}.json?postcode=WC2B+6NH"
         data = JSON.parse(last_response.body)
-        assert_equal 1, data.length
-        assert_equal @place2.name, data[0]['name']
+        assert_equal 2, data.length
+        assert_equal @place4.name, data[0]['name']
+        assert_equal @place3.name, data[1]['name']
       end
 
       should "return empty array if there are no places in the corresponding authority" do

--- a/test/unit/data_set_test.rb
+++ b/test/unit/data_set_test.rb
@@ -375,27 +375,21 @@ class DataSetTest < ActiveSupport::TestCase
       end
 
       should "return places in the same district as the postcode" do
-        mapit_has_a_postcode("EX39 1LH", [51.0413792674, -4.23640704632])
-
-        MapitApi.expects(:district_snac_for_postcode).with("EX39 1LH").returns("18UK")
+        mapit_has_a_postcode_and_areas("EX39 1LH", [51.0413792674, -4.23640704632], [{ "type" => "DIS", "ons" => "18UK"}])
 
         place_names = @data_set.places_for_postcode("EX39 1LH").map(&:name)
         assert_equal ["Susie's Tea Rooms", "John's Of Appledore"], place_names
       end
 
       should "return multiple places in order of nearness if there are more than one in the district" do
-        mapit_has_a_postcode("WC2B 6NH", [51.51695975170424, -0.12058693935709164])
-
-        MapitApi.expects(:district_snac_for_postcode).with("WC2B 6NH").returns("00AG")
+        mapit_has_a_postcode_and_areas("WC2B 6NH", [51.51695975170424, -0.12058693935709164], [{"type" => "DIS", "ons" => "00AG"}])
 
         place_names = @data_set.places_for_postcode("WC2B 6NH").map(&:name)
         assert_equal ["Aviation House", "FreeState Coffee"], place_names
       end
 
       should "return empty array if no SNAC can be found for the postcode" do
-        mapit_does_not_have_a_postcode("BT1 5GS")
-
-        MapitApi.expects(:district_snac_for_postcode).with("BT1 5GS").returns(nil)
+        mapit_has_a_postcode_and_areas("BT1 5GS", [21.54, -5.93], [])
 
         assert_equal [], @data_set.places_for_postcode("BT1 5GS").to_a
       end

--- a/test/unit/data_set_test.rb
+++ b/test/unit/data_set_test.rb
@@ -366,27 +366,35 @@ class DataSetTest < ActiveSupport::TestCase
 
         @place1 = FactoryGirl.create(:place, service_slug: @service.slug, snac: "18UK", postcode: "EX39 1QS",
                    location: Point.new(latitude: 51.05318361810428, longitude: -4.191071523498792), name: "John's Of Appledore")
-        @place2 = FactoryGirl.create(:place, service_slug: @service.slug, snac: "00AG", postcode: "WC2B 6NH",
+        @place2 = FactoryGirl.create(:place, service_slug: @service.slug, snac: "18UK", postcode: "EX39 1PP",
+                  location: Point.new(latitude: 51.053834, longitude: -4.191422), name: "Susie's Tea Rooms")
+        @place3 = FactoryGirl.create(:place, service_slug: @service.slug, snac: "00AG", postcode: "WC2B 6NH",
                    location: Point.new(latitude: 51.51695975170424, longitude: -0.12058693935709164), name: "Aviation House")
-        @place3 = FactoryGirl.create(:place, service_slug: @service.slug, snac: "00AG", postcode: "WC1B 5HA",
+        @place4 = FactoryGirl.create(:place, service_slug: @service.slug, snac: "00AG", postcode: "WC1B 5HA",
                    location: Point.new(latitude: 51.51837458322272, longitude: -0.12133586354538765), name: "FreeState Coffee")
       end
 
       should "return places in the same district as the postcode" do
+        mapit_has_a_postcode("EX39 1LH", [51.0413792674, -4.23640704632])
+
         MapitApi.expects(:district_snac_for_postcode).with("EX39 1LH").returns("18UK")
 
         place_names = @data_set.places_for_postcode("EX39 1LH").map(&:name)
-        assert_equal ["John's Of Appledore"], place_names
+        assert_equal ["Susie's Tea Rooms", "John's Of Appledore"], place_names
       end
 
-      should "return multiple places if there are more than one in the district" do
+      should "return multiple places in order of nearness if there are more than one in the district" do
+        mapit_has_a_postcode("WC2B 6NH", [51.51695975170424, -0.12058693935709164])
+
         MapitApi.expects(:district_snac_for_postcode).with("WC2B 6NH").returns("00AG")
 
         place_names = @data_set.places_for_postcode("WC2B 6NH").map(&:name)
-        assert_equal ["Aviation House", "FreeState Coffee"], place_names.sort
+        assert_equal ["Aviation House", "FreeState Coffee"], place_names
       end
 
       should "return empty array if no SNAC can be found for the postcode" do
+        mapit_does_not_have_a_postcode("BT1 5GS")
+
         MapitApi.expects(:district_snac_for_postcode).with("BT1 5GS").returns(nil)
 
         assert_equal [], @data_set.places_for_postcode("BT1 5GS").to_a


### PR DESCRIPTION
- The Local Authority place lookups were returning to the user in
  database-dependent order, meaning that people could potentially get
  the first result as somewhere on the other side of their city rather
  than next door.
- Some refactoring to make it less repetitive:
  - The way we had it working before, it was doing the same thing
  twice, once with the addition of a SNAC code as a parameter.
  This refactors the method, its tests and the underlying
  `MapitApi.district_snac_for_postcode` method so that if we already
  have location data from an existing call to MapIt (as in
  `places_for_postcode`) we don't have to call MapIt again to get
  something we already know.

Trello: https://trello.com/c/HzGA9mzs/298-add-nearness-ordering-to-la-bounded-place-lookup-in-imminence

(Paired with @h-lame to fix the failing tests.)