### PR TITLE
Allow Isles of Scilly in area type lookups

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,11 @@ Rails.application.routes.draw do
     root :to => 'services#index'
   end
 
-  get '/areas/:area_type', :to => 'areas#index', :constraints => { :area_type => /EUR|CTY|DIS|LBO|LGD|MTD|UTA/ }
+  # This list should stay in sync with Publisher's Area::AREA_TYPES
+  # https://github.com/alphagov/publisher/blob/master/app/models/area.rb#L7-L10
+  # and Business Support API's Scheme::WHITELISTED_AREA_CODES list:
+  # https://github.com/alphagov/business-support-api/blob/master/app/models/scheme.rb#L16-L18
+  get '/areas/:area_type', :to => 'areas#index', :constraints => { :area_type => /EUR|CTY|DIS|LBO|LGD|MTD|UTA|COI/ }
   get '/areas/:postcode', :to => 'areas#search', :constraints => { :postcode => /[\w% ]+/ }
 
   resources :places, :only => :show


### PR DESCRIPTION
They have their own special area type in mapit (COI) so we have to add
it to the constraint on the area_type in the route.  Also we add a
comment pointing out the other places that this constraint needs to be
synchronized with.

For: https://trello.com/c/BI5QN49V/308-add-isles-of-scilly-council-to-the-related-areas-tag-available-in-publisher-imminence-3

This doesn't live on it's own, it will not work unless we also merge / deploy: 

* https://github.com/alphagov/publisher/pull/449
* https://github.com/alphagov/business-support-api/pull/34
