### PR TITLE
Activate `redis-namespace`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ gem 'bootstrap-kaminari-views', '~> 0.0.3'
 
 gem 'sidekiq', '~> 4.1'
 gem 'sidekiq-statsd', '0.1.5'
+gem 'redis-namespace', '1.5.2'
 
 gem 'state_machines-mongoid', '~> 0.1.1'
 gem 'logstasher', '0.4.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -265,6 +265,8 @@ GEM
     rake (10.5.0)
     rdoc (4.2.0)
     redis (3.2.2)
+    redis-namespace (1.5.2)
+      redis (~> 3.0, >= 3.0.4)
     responders (2.1.0)
       railties (>= 4.2.0, < 5)
     rest-client (1.8.0)
@@ -380,6 +382,7 @@ DEPENDENCIES
   poltergeist (~> 1.7.0)
   pry
   rails (= 4.2.5.2)
+  redis-namespace (= 1.5.2)
   responders (~> 2.0)
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)


### PR DESCRIPTION
Sidekiq now requires you to activate the `redis-namespace` gem when
namespacing an instance of redis.