### PR TITLE
Support County-bounded LA lookups

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,0 +1,1 @@
+//= require 'modules/form-value-dependent'

--- a/app/assets/javascripts/modules/form-value-dependent.js
+++ b/app/assets/javascripts/modules/form-value-dependent.js
@@ -1,0 +1,26 @@
+(function(Modules) {
+  "use strict";
+
+  Modules.FormValueDependent = function() {
+    var that = this;
+
+    that.start = function(element) {
+      var controlElem = $('#'+element.data('form-value-dependent-elem'));
+      if (controlElem.length > 0) {
+        var controlValue = element.data('form-value-dependent-value'),
+          controlled = element,
+          toggleControlled = function() {
+            if (controlElem.val() === controlValue) {
+              controlled.show();
+            } else {
+              controlled.hide();
+            };
+          };
+
+        controlElem.on('change', toggleControlled);
+        toggleControlled();
+      };
+    };
+  };
+
+})(window.GOVUKAdmin.Modules);

--- a/app/helpers/services_helper.rb
+++ b/app/helpers/services_helper.rb
@@ -2,4 +2,8 @@ module ServicesHelper
   def service_location_match_type_options
     Service::LOCATION_MATCH_TYPES.map { |location_match_type| [location_match_type.humanize, location_match_type] }
   end
+
+  def service_local_authority_hierarchy_match_type_options
+    Service::LOCAL_AUTHORITY_HIERARCHY_MATCH_TYPES.map { |match_type| [match_type.humanize, match_type] }
+  end
 end

--- a/app/models/data_set.rb
+++ b/app/models/data_set.rb
@@ -62,7 +62,7 @@ class DataSet
     location_data = MapitApi.location_for_postcode(postcode)
     location = Point.new(latitude: location_data.lat, longitude: location_data.lon)
     if service.location_match_type == 'local_authority'
-      snac = MapitApi.extract_snac_from_mapit_response(location_data)
+      snac = MapitApi.extract_snac_from_mapit_response(location_data, service.local_authority_hierarchy_match_type)
       if snac
         places_near(location, distance, limit, snac)
       else

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -2,12 +2,16 @@ class Service
   include Mongoid::Document
 
   LOCATION_MATCH_TYPES = %w(nearest local_authority)
+  LOCAL_AUTHORITY_DISTRICT_MATCH = 'district'
+  LOCAL_AUTHORITY_COUNTY_MATCH = 'county'
+  LOCAL_AUTHORITY_HIERARCHY_MATCH_TYPES = [LOCAL_AUTHORITY_DISTRICT_MATCH, LOCAL_AUTHORITY_COUNTY_MATCH]
 
   field :name,                    type: String
   field :slug,                    type: String
   field :active_data_set_version, type: Integer, default: 1
   field :source_of_data,          type: String
   field :location_match_type,     type: String, default: LOCATION_MATCH_TYPES.first
+  field :local_authority_hierarchy_match_type, type: String, default: LOCAL_AUTHORITY_DISTRICT_MATCH
 
   embeds_many :data_sets do
     def current
@@ -22,6 +26,7 @@ class Service
   # underscore allowed because one of the existing services uses them in its slug.
   validates :slug, presence: true, uniqueness: true, format: {with: /\A[a-z0-9_-]*\z/ }
   validates :location_match_type, inclusion: {in: LOCATION_MATCH_TYPES}
+  validates :local_authority_hierarchy_match_type, inclusion: {in: LOCAL_AUTHORITY_HIERARCHY_MATCH_TYPES}
 
   before_validation :create_first_data_set, on: :create
   after_save :schedule_csv_processing

--- a/app/views/admin/services/_form_fields.html.erb
+++ b/app/views/admin/services/_form_fields.html.erb
@@ -12,6 +12,13 @@
   <%= f.input :local_authority_hierarchy_match_type, as: :select, input_html: {class: 'input-md-2'},
     collection: service_local_authority_hierarchy_match_type_options, include_blank: false,
     hint: "For services that use 'Local authority' location matching which council should be used for those areas that have a County and District hierarchy.",
+    wrapper_html: {
+      data: {
+        module: 'form-value-dependent',
+        'form-value-dependent-elem': 'service_location_match_type',
+        'form-value-dependent-value': 'local_authority'
+      }
+    }
   %>
 <% end %>
 

--- a/app/views/admin/services/_form_fields.html.erb
+++ b/app/views/admin/services/_form_fields.html.erb
@@ -9,6 +9,10 @@
     collection: service_location_match_type_options, include_blank: false,
     hint: "How places are matched for a given location."
   %>
+  <%= f.input :local_authority_hierarchy_match_type, as: :select, input_html: {class: 'input-md-2'},
+    collection: service_local_authority_hierarchy_match_type_options, include_blank: false,
+    hint: "For services that use 'Local authority' location matching which council should be used for those areas that have a County and District hierarchy.",
+  %>
 <% end %>
 
 <%= f.actions do %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,6 +3,7 @@
 <% content_for :head do %>
   <%= csrf_meta_tags %>
   <%= stylesheet_link_tag 'application' %>
+  <%= javascript_include_tag 'application' %>
   <%= yield :extra_headers %>
 <% end %>
 

--- a/lib/mapit_api.rb
+++ b/lib/mapit_api.rb
@@ -1,6 +1,7 @@
 module MapitApi
   class InvalidPostcodeError < StandardError; end
   class ValidPostcodeNoLocation < StandardError; end
+  class InvalidLocationHierarchyType < ArgumentError; end
 
   def self.location_for_postcode(postcode)
     location_data = Imminence.mapit_api.location_for_postcode(postcode)
@@ -33,6 +34,8 @@ module MapitApi
       DISTRICT_TYPES
     when 'county'
       COUNTY_TYPES
+    else
+      raise InvalidLocationHierarchyType.new(location_hiearachy_type)
     end
   end
   private_class_method :area_types

--- a/lib/mapit_api.rb
+++ b/lib/mapit_api.rb
@@ -14,16 +14,28 @@ module MapitApi
   # See http://mapit.mysociety.org/#api-multiple_areas for details
   # of the various area types.
   DISTRICT_TYPES = %w(DIS LBO MTD UTA COI).freeze
+  COUNTY_TYPES = %w(CTY LBO MTD UTA COI).freeze
 
   def self.district_snac_for_postcode(postcode)
     location_data = location_for_postcode(postcode)
-    extract_snac_from_mapit_response(location_data)
+    extract_snac_from_mapit_response(location_data, 'district')
   end
 
-  def self.extract_snac_from_mapit_response(location_data)
-    district = location_data.areas.detect { |area| DISTRICT_TYPES.include?(area.type) }
-    district.codes['ons'] if district
+  def self.extract_snac_from_mapit_response(location_data, location_hiearachy_type)
+    area_types_to_check = area_types(location_hiearachy_type)
+    found_area = location_data.areas.detect { |area| area_types_to_check.include?(area.type) }
+    found_area.codes['ons'] if found_area
   end
+
+  def self.area_types(location_hiearachy_type)
+    case location_hiearachy_type
+    when 'district'
+      DISTRICT_TYPES
+    when 'county'
+      COUNTY_TYPES
+    end
+  end
+  private_class_method :area_types
 
   class AreasByTypeResponse
     def initialize(response)

--- a/test/factories/places_factories.rb
+++ b/test/factories/places_factories.rb
@@ -6,6 +6,11 @@ FactoryGirl.define do
   end
 
   factory :place do
+    transient do
+      latitude { 53.105491 }
+      longitude { -2.017493 }
+    end
+
     service_slug { (Service.first || create(:service)).slug }
     data_set_version { Service.where(slug: service_slug).first.active_data_set_version }
     name "CosaNostra Pizza #3569"
@@ -13,6 +18,6 @@ FactoryGirl.define do
     town "Los Angeles"
     postcode "WC2B 6NH"
     phone "01234 567890"
-    location { Point.new(latitude: 53.105491, longitude: -2.017493) }
+    location { Point.new(latitude: latitude, longitude: longitude) }
   end
 end

--- a/test/integration/places_api_test.rb
+++ b/test/integration/places_api_test.rb
@@ -2,19 +2,45 @@ require_relative '../integration_test_helper'
 require 'csv'
 
 class PlacesAPITest < ActionDispatch::IntegrationTest
+  include GdsApi::TestHelpers::Mapit
+
   context "Requesting the full dataset" do
     setup do
       @service = FactoryGirl.create(:service)
       @data_set_1 = @service.active_data_set
       @data_set_2 = @service.data_sets.create
-      @place1_1 = FactoryGirl.create(:place, service_slug: @service.slug, data_set_version: @data_set_1.version,
-                  location: Point.new(latitude: 51.613314, longitude: -0.158278), name: "Town Hall")
-      @place1_2 = FactoryGirl.create(:place, service_slug: @service.slug, data_set_version: @data_set_1.version,
-                  location: Point.new(latitude: 51.500728, longitude: -0.124626), name: "Palace of Westminster")
-      @place2_1 = FactoryGirl.create(:place, service_slug: @service.slug, data_set_version: @data_set_2.version,
-                  location: Point.new(latitude: 51.613314, longitude: -0.158278), name: "Town Hall 2")
-      @place2_2 = FactoryGirl.create(:place, service_slug: @service.slug, data_set_version: @data_set_2.version,
-                  location: Point.new(latitude: 51.500728, longitude: -0.124626), name: "Palace of Westminster 2")
+      @place1_1 = FactoryGirl.create(
+        :place,
+        service_slug: @service.slug,
+        data_set_version: @data_set_1.version,
+        latitude: 51.613314,
+        longitude: -0.158278,
+        name: "Town Hall"
+      )
+      @place1_2 = FactoryGirl.create(
+        :place,
+        service_slug: @service.slug,
+        data_set_version: @data_set_1.version,
+        latitude: 51.500728,
+        longitude: -0.124626,
+        name: "Palace of Westminster"
+      )
+      @place2_1 = FactoryGirl.create(
+        :place,
+        service_slug: @service.slug,
+        data_set_version: @data_set_2.version,
+        latitude: 51.613314,
+        longitude: -0.158278,
+        name: "Town Hall 2"
+      )
+      @place2_2 = FactoryGirl.create(
+        :place,
+        service_slug: @service.slug,
+        data_set_version: @data_set_2.version,
+        latitude: 51.500728,
+        longitude: -0.124626,
+        name: "Palace of Westminster 2"
+      )
       @data_set_2.activate
     end
 
@@ -71,10 +97,20 @@ class PlacesAPITest < ActionDispatch::IntegrationTest
     context "for a geo-distance service" do
       setup do
         @service = FactoryGirl.create(:service)
-        @place1 = FactoryGirl.create(:place, service_slug: @service.slug,
-                  location: Point.new(latitude: 51.613314, longitude: -0.158278), name: "Town Hall")
-        @place2 = FactoryGirl.create(:place, service_slug: @service.slug,
-                  location: Point.new(latitude: 51.500728, longitude: -0.124626), name: "Palace of Westminster")
+        @place1 = FactoryGirl.create(
+          :place,
+          service_slug: @service.slug,
+          latitude: 51.613314,
+          longitude: -0.158278,
+          name: "Town Hall"
+        )
+        @place2 = FactoryGirl.create(
+          :place,
+          service_slug: @service.slug,
+          latitude: 51.500728,
+          longitude: -0.124626,
+          name: "Palace of Westminster"
+        )
       end
 
       should "return places near the given postcode" do
@@ -112,18 +148,41 @@ class PlacesAPITest < ActionDispatch::IntegrationTest
       end
     end
 
-
     context "for an authority-bounded service" do
       setup do
         @service = FactoryGirl.create(:service, location_match_type: 'local_authority')
-        @place1 = FactoryGirl.create(:place, service_slug: @service.slug, snac: "18UK",
-                  location: Point.new(latitude: 51.0519276, longitude: -4.1907002), name: "John's Of Appledore")
-        @place2 = FactoryGirl.create(:place, service_slug: @service.slug, snac: "18UK",
-                  location: Point.new(latitude: 51.053834, longitude: -4.191422), name: "Susie's Tea Rooms")
-        @place3 = FactoryGirl.create(:place, service_slug: @service.slug, snac: "00AG",
-                  location: Point.new(latitude: 51.500728, longitude: -0.124626), name: "Palace of Westminster")
-        @place4 = FactoryGirl.create(:place, service_slug: @service.slug, snac: "00AG",
-                  location: Point.new(latitude: 51.51837458322272, longitude: -0.12133586354538765), name: "FreeState Coffee")
+        @place1 = FactoryGirl.create(
+          :place,
+          service_slug: @service.slug,
+          snac: "18UK",
+          latitude: 51.0519276,
+          longitude: -4.1907002,
+          name: "John's Of Appledore"
+        )
+        @place2 = FactoryGirl.create(
+          :place,
+          service_slug: @service.slug,
+          snac: "18UK",
+          latitude: 51.053834,
+          longitude: -4.191422,
+          name: "Susie's Tea Rooms"
+        )
+        @place3 = FactoryGirl.create(
+          :place,
+          service_slug: @service.slug,
+          snac: "00AG",
+          latitude: 51.500728,
+          longitude: -0.124626,
+          name: "Palace of Westminster"
+        )
+        @place4 = FactoryGirl.create(
+          :place,
+          service_slug: @service.slug,
+          snac: "00AG",
+          latitude: 51.51837458322272,
+          longitude: -0.12133586354538765,
+          name: "FreeState Coffee"
+        )
       end
 
       should "return the place(s) for the authority corresponding to the postcode in order of nearness" do

--- a/test/integration/places_api_test.rb
+++ b/test/integration/places_api_test.rb
@@ -211,7 +211,7 @@ class PlacesAPITest < ActionDispatch::IntegrationTest
       end
 
       should "return a 400 for an invalid postcode" do
-        GdsApi::Mapit.any_instance.expects(:location_for_postcode).with('N11 3QQ').returns(nil)
+        mapit_does_not_have_a_postcode('N11 3QQ')
 
         get "/places/#{@service.slug}.json?postcode=N11+3QQ"
         assert_equal 400, last_response.status

--- a/test/integration/places_api_test.rb
+++ b/test/integration/places_api_test.rb
@@ -183,23 +183,22 @@ class PlacesAPITest < ActionDispatch::IntegrationTest
           longitude: -0.12133586354538765,
           name: "FreeState Coffee"
         )
-      end
-
-      should "return the place(s) for the authority corresponding to the postcode in order of nearness" do
-        stub_mapit_postcode_response_from_fixture("EX39 1QS")
-        stub_mapit_postcode_response_from_fixture("WC2B 6NH")
-
-        get "/places/#{@service.slug}.json?postcode=EX39+1QS"
-        data = JSON.parse(last_response.body)
-        assert_equal 2, data.length
-        assert_equal @place2.name, data[0]['name']
-        assert_equal @place1.name, data[1]['name']
-
-        get "/places/#{@service.slug}.json?postcode=WC2B+6NH"
-        data = JSON.parse(last_response.body)
-        assert_equal 2, data.length
-        assert_equal @place4.name, data[0]['name']
-        assert_equal @place3.name, data[1]['name']
+        @place5 = FactoryGirl.create(
+          :place,
+          service_slug: @service.slug,
+          snac: "18",
+          latitude: 51.05420,
+          longitude: -4.19096,
+          name: "The Coffee Cabin"
+        )
+        @place6 = FactoryGirl.create(
+          :place,
+          service_slug: @service.slug,
+          snac: "18",
+          latitude: 51.05289,
+          longitude: -4.19111,
+          name: "The Quay Restaurant and Gallery"
+        )
       end
 
       should "return empty array if there are no places in the corresponding authority" do
@@ -215,6 +214,58 @@ class PlacesAPITest < ActionDispatch::IntegrationTest
 
         get "/places/#{@service.slug}.json?postcode=N11+3QQ"
         assert_equal 400, last_response.status
+      end
+
+      context "when the service is bounded to districts" do
+        setup do
+          @service.update_attributes(local_authority_hierarchy_match_type: Service::LOCAL_AUTHORITY_DISTRICT_MATCH)
+        end
+
+        should "return the district places in order of nearness, not the county ones for postcodes in a county+district council hierarchy" do
+          stub_mapit_postcode_response_from_fixture("EX39 1QS")
+
+          get "/places/#{@service.slug}.json?postcode=EX39+1QS"
+          data = JSON.parse(last_response.body)
+          assert_equal 2, data.length
+          assert_equal @place2.name, data[0]['name']
+          assert_equal @place1.name, data[1]['name']
+        end
+
+        should "return all the places in order of nearness for postcodes not in a county+district council hierarchy" do
+          stub_mapit_postcode_response_from_fixture("WC2B 6NH")
+
+          get "/places/#{@service.slug}.json?postcode=WC2B+6NH"
+          data = JSON.parse(last_response.body)
+          assert_equal 2, data.length
+          assert_equal @place4.name, data[0]['name']
+          assert_equal @place3.name, data[1]['name']
+        end
+      end
+
+      context "when the service is bounded to counties" do
+        setup do
+          @service.update_attributes(local_authority_hierarchy_match_type: Service::LOCAL_AUTHORITY_COUNTY_MATCH)
+        end
+
+        should "only return the county results in order of nearness, not the district ones for postcodes in a county+district council hierarchy" do
+          stub_mapit_postcode_response_from_fixture("EX39 1QS")
+
+          get "/places/#{@service.slug}.json?postcode=EX39+1QS"
+          data = JSON.parse(last_response.body)
+          assert_equal 2, data.length
+          assert_equal @place6.name, data[0]['name']
+          assert_equal @place5.name, data[1]['name']
+        end
+
+        should "return all the places in order of nearness for postcodes not in a county+district council hierarchy" do
+          stub_mapit_postcode_response_from_fixture("WC2B 6NH")
+
+          get "/places/#{@service.slug}.json?postcode=WC2B+6NH"
+          data = JSON.parse(last_response.body)
+          assert_equal 2, data.length
+          assert_equal @place4.name, data[0]['name']
+          assert_equal @place3.name, data[1]['name']
+        end
       end
     end
   end

--- a/test/unit/data_set_test.rb
+++ b/test/unit/data_set_test.rb
@@ -364,14 +364,42 @@ class DataSetTest < ActiveSupport::TestCase
         @service = FactoryGirl.create(:service, location_match_type: 'local_authority')
         @data_set = @service.latest_data_set
 
-        @place1 = FactoryGirl.create(:place, service_slug: @service.slug, snac: "18UK", postcode: "EX39 1QS",
-                   location: Point.new(latitude: 51.05318361810428, longitude: -4.191071523498792), name: "John's Of Appledore")
-        @place2 = FactoryGirl.create(:place, service_slug: @service.slug, snac: "18UK", postcode: "EX39 1PP",
-                  location: Point.new(latitude: 51.053834, longitude: -4.191422), name: "Susie's Tea Rooms")
-        @place3 = FactoryGirl.create(:place, service_slug: @service.slug, snac: "00AG", postcode: "WC2B 6NH",
-                   location: Point.new(latitude: 51.51695975170424, longitude: -0.12058693935709164), name: "Aviation House")
-        @place4 = FactoryGirl.create(:place, service_slug: @service.slug, snac: "00AG", postcode: "WC1B 5HA",
-                   location: Point.new(latitude: 51.51837458322272, longitude: -0.12133586354538765), name: "FreeState Coffee")
+        @place1 = FactoryGirl.create(
+          :place,
+          service_slug: @service.slug,
+          snac: "18UK",
+          postcode: "EX39 1QS",
+          latitude: 51.05318361810428,
+          longitude: -4.191071523498792,
+          name: "John's Of Appledore"
+        )
+        @place2 = FactoryGirl.create(
+          :place,
+          service_slug: @service.slug,
+          snac: "18UK",
+          postcode: "EX39 1PP",
+          latitude: 51.053834,
+          longitude: -4.191422,
+          name: "Susie's Tea Rooms"
+        )
+        @place3 = FactoryGirl.create(
+          :place,
+          service_slug: @service.slug,
+          snac: "00AG",
+          postcode: "WC2B 6NH",
+          latitude: 51.51695975170424,
+          longitude: -0.12058693935709164,
+          name: "Aviation House"
+        )
+        @place4 = FactoryGirl.create(
+          :place,
+          service_slug: @service.slug,
+          snac: "00AG",
+          postcode: "WC1B 5HA",
+          latitude: 51.51837458322272,
+          longitude: -0.12133586354538765,
+          name: "FreeState Coffee"
+        )
       end
 
       should "return places in the same district as the postcode" do

--- a/test/unit/lib/mapit_api_test.rb
+++ b/test/unit/lib/mapit_api_test.rb
@@ -110,6 +110,14 @@ class MapitApiTest < ActiveSupport::TestCase
         assert_nil MapitApi.extract_snac_from_mapit_response(location_data, 'county')
       end
     end
+
+    context 'when asked to extract any other type of snac code' do
+      should 'raise a InvalidLocationHierarchyType exception' do
+        assert_raises(MapitApi::InvalidLocationHierarchyType) do
+          MapitApi.extract_snac_from_mapit_response(stub(areas: []), 'super output area')
+        end
+      end
+    end
   end
 
   context "valid_post_code_no_location" do

--- a/test/unit/presenters/data_set_csv_presenter_test.rb
+++ b/test/unit/presenters/data_set_csv_presenter_test.rb
@@ -41,10 +41,15 @@ class DataSetCsvPresenterTest < ActiveSupport::TestCase
 
   context "presenting a dataset with a place" do
     setup do
-      @place = FactoryGirl.create(:place, service_slug: @service.slug,
-                                  data_set_version: @data_set.version,
-                                  email: "camden@example.com", snac: "00AG",
-                                  override_lng: 0.0, override_lat: 1.0)
+      @place = FactoryGirl.create(
+        :place,
+        service_slug: @service.slug,
+        data_set_version: @data_set.version,
+        email: "camden@example.com",
+        snac: "00AG",
+        override_lng: 0.0,
+        override_lat: 1.0
+      )
       @result = @presenter.to_array_for_csv
     end
 

--- a/test/unit/service_test.rb
+++ b/test/unit/service_test.rb
@@ -74,10 +74,30 @@ class ServiceTest < ActiveSupport::TestCase
         assert_equal 1, @service.errors[:location_match_type].count
       end
     end
+
+    should "require local_authority_hierarchy_match_type to be one of the allowed values" do
+      Service::LOCAL_AUTHORITY_HIERARCHY_MATCH_TYPES.each do |match_type|
+        @service.local_authority_hierarchy_match_type = match_type
+        assert @service.valid?, "Expected service to be valid with local_authority_hierarchy_match_type: '#{match_type}'"
+      end
+
+      [
+        '',
+        'fooey',
+      ].each do |match_type|
+        @service.local_authority_hierarchy_match_type = match_type
+        refute @service.valid?, "Expected service to be invalid with local_authority_hierarchy_match_type: '#{match_type}'"
+        assert_equal 1, @service.errors[:local_authority_hierarchy_match_type].count
+      end
+    end
   end
 
   should "default location_match_type to 'nearest'" do
     assert_equal 'nearest', Service.new.location_match_type
+  end
+
+  should "default local_authority_hierarchy_match_type to 'district'" do
+    assert_equal 'district', Service.new.local_authority_hierarchy_match_type
   end
 
   should "create an initial data_set when creating a service" do


### PR DESCRIPTION
For: https://trello.com/c/IPhkbBfw/325-add-new-flag-for-local-authority-type-services-in-imminence-2

Some councils in England live in a two-tier hierarchy with smaller Districts living inside larger Counties (e.g. South Buckinghamshire District within Buckinghamshire County Council).  Some services are delivered at the district level whereas others are delivered at the county level.  For a "find my nearest" service that is bounded to show results from your local authority Imminence only does a district level match.  This means if we want to provide a service that is provided at the county level we have to duplicate all the data for each district.  This PR changes that to allow choosing which part of the council hierarchy to use for the match: district or county.

The setting has no effect on postcodes that are not in two-tier council hierarchies (e.g. Unitary or Metropolitan boroughs).

The change to the admin UI is:

### Before

![imminence-before](https://cloud.githubusercontent.com/assets/608/13635871/71bf2d38-e5f6-11e5-8ae2-78fdb26106a1.jpg)

### After

![imminence-after](https://cloud.githubusercontent.com/assets/608/13635874/73b74512-e5f6-11e5-8eb3-d7049b27e885.jpg)

Note that the new dropdown to select the hierarchy match only appears if you choose "Local authority" from the "Location match type" dropdown.