### PR TITLE
Move dataset csv out of document

### DIFF
--- a/app/controllers/admin/data_sets_controller.rb
+++ b/app/controllers/admin/data_sets_controller.rb
@@ -4,14 +4,16 @@ require "imminence/file_verifier"
 class Admin::DataSetsController < InheritedResources::Base
   include Admin::AdminControllerMixin
 
-  actions :all, except: [:index, :destroy]
+  actions :all, except: [:new, :index, :destroy]
   belongs_to :service
   rescue_from CSV::MalformedCSVError, with: :bad_csv
   rescue_from InvalidCharacterEncodingError, with: :bad_encoding
 
   def create
     prohibit_non_csv_uploads
-    create!
+    create! do |_success, failure|
+      failure.html { render 'new_data' }
+    end
   end
 
   def duplicate

--- a/app/models/csv_data.rb
+++ b/app/models/csv_data.rb
@@ -1,0 +1,51 @@
+class CsvData
+  include Mongoid::Document
+  include Mongoid::Timestamps
+
+  field :service_slug, type: String
+  field :data_set_version, type: Integer
+  field :data, type: String
+
+  # Mongoid has a 16M limit on document size.  Set this to
+  # 15M to leave some headroom for storing the rest of the document.
+  validates :data, length: { maximum: 15.megabytes, message: "CSV file is too big (max is 15MB)" }
+  validates_presence_of :service_slug
+  validates_presence_of :data_set_version
+  validates_presence_of :data
+
+  def service
+    @_service ||= Service.where(slug: service_slug).first
+  end
+
+  def data_set
+    @_data_set ||= service.data_sets.where(version: data_set_version).first if service
+  end
+
+  def data_file=(file)
+    self.data =
+      if file.nil?
+        nil
+      else
+        read_as_utf8(file)
+      end
+  end
+
+private
+
+  def read_as_utf8(file)
+    string = file.read.force_encoding('utf-8')
+    unless string.valid_encoding?
+      # Try windows-1252 (which is a superset of iso-8859-1)
+      string.force_encoding('windows-1252')
+      # Any stream of bytes should be a vaild Windows-1252 string, so we use the presence of any
+      # ASCII control chars (except for \r and \n) as a good heuristic to determine if this is
+      # likely to be the correct charset
+      if string.valid_encoding? && ! string.match(/[\x00-\x09\x0b\x0c\x0e-\x1f]/)
+        return string.encode('utf-8')
+      end
+
+      raise InvalidCharacterEncodingError, "Unknown character encoding"
+    end
+    string
+  end
+end

--- a/app/models/data_set.rb
+++ b/app/models/data_set.rb
@@ -122,7 +122,11 @@ class DataSet
     return if @csv_data.nil? || @csv_data.destroyed?
     @csv_data.service_slug = service.slug
     @csv_data.data_set_version = self.version
-    errors.add(:csv_data, @csv_data.errors) unless @csv_data.valid?
+    unless @csv_data.valid?
+      @csv_data.errors[:data].each do |message|
+        errors.add(:data_file, message)
+      end
+    end
   end
 
   def reset_csv_data

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -36,15 +36,13 @@ class Service
   end
 
   def data_file=(file)
-    ds = self.data_sets.build
-    ds.data_file = file
-    @need_csv_processing = true
+    @need_csv_processing = self.data_sets.build(data_file: file)
   end
 
   def schedule_csv_processing
     if @need_csv_processing
-      ProcessCsvDataWorker.perform_async(self.id.to_s, latest_data_set.version)
-      @need_csv_processing = false
+      @need_csv_processing.schedule_csv_processing
+      @need_csv_processing = nil
     end
   end
 

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -30,6 +30,7 @@ class Service
 
   before_validation :create_first_data_set, on: :create
   after_save :schedule_csv_processing
+  after_validation :promote_data_file_errors
 
   def reconcile_place_locations
     data_sets.first.places.map(&:reconcile_location)
@@ -43,6 +44,14 @@ class Service
     if @need_csv_processing
       @need_csv_processing.schedule_csv_processing
       @need_csv_processing = nil
+    end
+  end
+
+  def promote_data_file_errors
+    if @need_csv_processing
+      @need_csv_processing.errors[:data_file].each do |message|
+        errors.add(:data_file, message)
+      end
     end
   end
 

--- a/app/views/admin/data_sets/new_data.html.erb
+++ b/app/views/admin/data_sets/new_data.html.erb
@@ -1,0 +1,20 @@
+<% content_for :page_title, @data_set.service.name %>
+<%= render 'admin/services/overview' %>
+
+<section class="panel panel-default">
+  <header class="panel-heading">
+    <h4 class="panel-title">Upload a new data set</h4>
+  </header>
+  <div class="panel-body">
+    <%= render '/admin/data_sets/file_help' %>
+    <%= semantic_form_for(@data_set, :url => admin_service_data_sets_path(@data_set.service), :html => {:multipart => true}) do |f| %>
+      <%= f.inputs do %>
+        <%= f.input :data_file, :as => :file, :accept => 'text/csv' %>
+        <%= f.input :change_notes, :as => :text, :label => "Change note",  input_html: {class: 'input-md-6'}%>
+      <% end %>
+      <%= f.actions do %>
+        <%= f.submit "Create Data set", class: 'btn btn-primary' %>
+      <% end %>
+    <% end %>
+  </div>
+</section>

--- a/test/unit/csv_data_test.rb
+++ b/test/unit/csv_data_test.rb
@@ -1,0 +1,104 @@
+require 'test_helper'
+
+class CsvDataTest < ActiveSupport::TestCase
+  context 'associations' do
+    setup do
+      @service = Service.create! slug: 'chickens', name: 'Chickens!'
+      @data_set = @service.data_sets.create! version: 2
+      @csv_data = CsvData.create!(
+        service_slug: 'chickens',
+        data_set_version: 2,
+        data: "1,2,3"
+      )
+    end
+
+    should "can look up the service it belongs to" do
+      assert_equal @service, @csv_data.service
+    end
+
+    should "can look up the data set it belongs to" do
+      s = Service.create! slug: 'ducks', name: 'Ducks!'
+      s.data_sets.create! version: 2
+
+      assert_equal @data_set, @csv_data.data_set
+    end
+  end
+
+  context "validations" do
+    should 'be invalid without a service slug' do
+      csv_data = CsvData.create(service_slug: nil, data_set_version: 2, data: '1,2,3')
+      refute csv_data.valid?
+      assert_equal 1, csv_data.errors[:service_slug].size
+    end
+
+    should 'be invalid without a data set version' do
+      csv_data = CsvData.create(service_slug: 'foo', data_set_version: nil, data: '1,2,3')
+      refute csv_data.valid?
+      assert_equal 1, csv_data.errors[:data_set_version].size
+    end
+
+    should 'be invalid without data' do
+      csv_data = CsvData.create(service_slug: 'foo', data_set_version: 2, data: nil)
+      refute csv_data.valid?
+      assert_equal 1, csv_data.errors[:data].size
+    end
+
+    context "validating file size" do
+      setup do
+        @service = Service.create! slug: 'chickens', name: 'Chickens!'
+        @data_set = @service.data_sets.create! version: 2
+      end
+
+      should "be valid with a file up to 15M" do
+        csv_data = CsvData.create(service_slug: 'chickens', data_set_version: 2, data: "x" * (15.megabytes - 1))
+        assert csv_data.valid?
+      end
+
+      should "be invalid with a file over 15M" do
+        csv_data = CsvData.create(service_slug: 'chickens', data_set_version: 2, data: "x" * (15.megabytes + 1))
+        refute csv_data.valid?
+        assert_equal 1, csv_data.errors[:data].size
+      end
+    end
+
+    context "handling various file encodings" do
+      setup do
+        @csv_data = CsvData.new(service_slug: 'foo', data_set_version: 2)
+      end
+
+      should "handle ASCII files" do
+        @csv_data.data_file = File.open(fixture_file_path('encodings/ascii.csv'), encoding: 'ascii-8bit')
+        @csv_data.save!
+        expected = File.read(fixture_file_path('encodings/ascii.csv'))
+        assert_equal expected, @csv_data.data
+      end
+
+      should "handle UTF-8 files" do
+        @csv_data.data_file = File.open(fixture_file_path('encodings/utf-8.csv'), encoding: 'ascii-8bit')
+        @csv_data.save!
+        expected = File.read(fixture_file_path('encodings/utf-8.csv'))
+        assert_equal expected, @csv_data.data
+      end
+
+      should "handle ISO-8859-1 files" do
+        @csv_data.data_file = File.open(fixture_file_path('encodings/iso-8859-1.csv'), encoding: 'ascii-8bit')
+        @csv_data.save!
+        expected = File.read(fixture_file_path('encodings/iso-8859-1.csv')).force_encoding('iso-8859-1').encode('utf-8')
+        assert_equal expected, @csv_data.data
+      end
+
+      should "handle Windows 1252 files" do
+        @csv_data.data_file = File.open(fixture_file_path('encodings/windows-1252.csv'), encoding: 'ascii-8bit')
+        @csv_data.save!
+        expected = File.read(fixture_file_path('encodings/windows-1252.csv')).force_encoding('windows-1252').encode('utf-8')
+        assert_equal expected, @csv_data.data
+      end
+
+      should "raise an error with an unknown file encoding" do
+        assert_raise InvalidCharacterEncodingError do
+          @csv_data.data_file = File.open(fixture_file_path('encodings/utf-16le.csv'), encoding: 'ascii-8bit')
+        end
+      end
+    end
+  end
+end

--- a/test/unit/data_set_test.rb
+++ b/test/unit/data_set_test.rb
@@ -46,7 +46,7 @@ class DataSetTest < ActiveSupport::TestCase
     should "do nothing and return false if the data_set hasn't completed processing" do
       previous_active_set = @service.active_data_set
 
-      ds = @service.data_sets.create!(csv_data: "something")
+      ds = @service.data_sets.create!(data_file: StringIO.new("something"))
       refute ds.activate
 
       @service.reload
@@ -101,7 +101,7 @@ class DataSetTest < ActiveSupport::TestCase
     should "create a data_set, store the csv_data and queue a job to process it" do
       ds = @service.data_sets.create!(data_file: File.open(fixture_file_path('good_csv.csv')))
 
-      assert_equal File.read(fixture_file_path('good_csv.csv')), ds.csv_data
+      assert_equal File.read(fixture_file_path('good_csv.csv')), ds.csv_data.data
 
       job = ProcessCsvDataWorker.jobs.last
       service_id_to_process, version_to_process = *job['args']
@@ -116,12 +116,12 @@ class DataSetTest < ActiveSupport::TestCase
       end
 
       should "be valid with a file up to 15M" do
-        @ds.csv_data = "x" * (15.megabytes - 1)
+        @ds.data_file = StringIO.new("x" * (15.megabytes - 1))
         assert @ds.valid?
       end
 
       should "be invalid with a file over 15M" do
-        @ds.csv_data = "x" * (15.megabytes + 1)
+        @ds.data_file = StringIO.new("x" * (15.megabytes + 1))
         refute @ds.valid?
         assert_equal 1, @ds.errors[:csv_data].size
       end
@@ -136,28 +136,28 @@ class DataSetTest < ActiveSupport::TestCase
         @ds.data_file = File.open(fixture_file_path('encodings/ascii.csv'), encoding: 'ascii-8bit')
         @ds.save!
         expected = File.read(fixture_file_path('encodings/ascii.csv'))
-        assert_equal expected, @ds.csv_data
+        assert_equal expected, @ds.csv_data.data
       end
 
       should "handle UTF-8 files" do
         @ds.data_file = File.open(fixture_file_path('encodings/utf-8.csv'), encoding: 'ascii-8bit')
         @ds.save!
         expected = File.read(fixture_file_path('encodings/utf-8.csv'))
-        assert_equal expected, @ds.csv_data
+        assert_equal expected, @ds.csv_data.data
       end
 
       should "handle ISO-8859-1 files" do
         @ds.data_file = File.open(fixture_file_path('encodings/iso-8859-1.csv'), encoding: 'ascii-8bit')
         @ds.save!
         expected = File.read(fixture_file_path('encodings/iso-8859-1.csv')).force_encoding('iso-8859-1').encode('utf-8')
-        assert_equal expected, @ds.csv_data
+        assert_equal expected, @ds.csv_data.data
       end
 
       should "handle Windows 1252 files" do
         @ds.data_file = File.open(fixture_file_path('encodings/windows-1252.csv'), encoding: 'ascii-8bit')
         @ds.save!
         expected = File.read(fixture_file_path('encodings/windows-1252.csv')).force_encoding('windows-1252').encode('utf-8')
-        assert_equal expected, @ds.csv_data
+        assert_equal expected, @ds.csv_data.data
       end
 
       should "raise an error with an unknown file encoding" do
@@ -176,7 +176,7 @@ class DataSetTest < ActiveSupport::TestCase
     end
 
     should "add all places from the csv_data" do
-      ds = @service.data_sets.create!(csv_data: File.read(fixture_file_path('good_csv.csv')))
+      ds = @service.data_sets.create!(data_file: File.open(fixture_file_path('good_csv.csv')))
       ds.process_csv_data
 
       assert_equal 1, ds.places.count
@@ -184,7 +184,7 @@ class DataSetTest < ActiveSupport::TestCase
     end
 
     should "clear the stored csv_data" do
-      ds = @service.data_sets.create!(csv_data: File.read(fixture_file_path('good_csv.csv')))
+      ds = @service.data_sets.create!(data_file: File.open(fixture_file_path('good_csv.csv')))
       ds.process_csv_data
 
       ds.reload
@@ -192,7 +192,7 @@ class DataSetTest < ActiveSupport::TestCase
     end
 
     should "store an error message, and clear the csv_data with an invalid csv" do
-      ds = @service.data_sets.create!(csv_data: File.read(fixture_file_path('bad_csv.csv')))
+      ds = @service.data_sets.create!(data_file: File.open(fixture_file_path('bad_csv.csv')))
       ds.process_csv_data
 
       ds.reload
@@ -202,17 +202,17 @@ class DataSetTest < ActiveSupport::TestCase
 
     context "processing state predicates" do
       should "be processing_complete with no csv_data and no processing_error" do
-        ds = @service.data_sets.build(csv_data: nil, processing_error: nil)
+        ds = @service.data_sets.build(data_file: nil, processing_error: nil)
         assert ds.processing_complete?
       end
 
       should "not be processing_complete with csv_data" do
-        ds = @service.data_sets.build(csv_data: "anything", processing_error: nil)
+        ds = @service.data_sets.build(data_file: StringIO.new("anything"), processing_error: nil)
         refute ds.processing_complete?
       end
 
       should "not be processing_complete with processing_error" do
-        ds = @service.data_sets.build(csv_data: nil, processing_error: "something went wrong")
+        ds = @service.data_sets.build(data_file: nil, processing_error: "something went wrong")
         refute ds.processing_complete?
       end
     end

--- a/test/unit/data_set_test.rb
+++ b/test/unit/data_set_test.rb
@@ -123,7 +123,7 @@ class DataSetTest < ActiveSupport::TestCase
       should "be invalid with a file over 15M" do
         @ds.data_file = StringIO.new("x" * (15.megabytes + 1))
         refute @ds.valid?
-        assert_equal 1, @ds.errors[:csv_data].size
+        assert_equal 1, @ds.errors[:data_file].size
       end
     end
 

--- a/test/unit/service_test.rb
+++ b/test/unit/service_test.rb
@@ -119,7 +119,8 @@ class ServiceTest < ActiveSupport::TestCase
       s = Service.create!(attrs)
 
       assert_equal 1, s.data_sets.count
-      assert_equal File.read(fixture_file_path('good_csv.csv')), s.latest_data_set.csv_data
+      assert s.latest_data_set.csv_data
+      assert_equal File.read(fixture_file_path('good_csv.csv')), s.latest_data_set.csv_data.data
 
       job = ProcessCsvDataWorker.jobs.last
       service_id_to_process, version_to_process = *job['args']


### PR DESCRIPTION
See for full context: https://trello.com/c/Jf47Ad7K/319-stop-previous-uncompleted-imminence-csv-upload-jobs-from-preventing-future-updates-to-a-service-5

tl;dr - when the CSV processing job is killed it can leave the CSV data left on the DataSet.  If this happens often enough to data sets that belong to the same service then the service object can become too big for mongoid to store (16Mb limit) because the data sets are not independent documents, but are embedded inside the service.  This means users are unable to upload new data, which they almost always want to do because the previous upload has just been killed without completing.  

This PR moves the CSV data out of the embedded data sets and into their own mongoid documents.  We considered other options but decided this was the quickest solution for now and have a backlog story to think about more robust solutions.