### PR TITLE
Allow local_authority_hierarchy_match_type param

### DIFF
--- a/app/controllers/admin/services_controller.rb
+++ b/app/controllers/admin/services_controller.rb
@@ -32,7 +32,7 @@ protected
   end
 
   def service_params
-    permitted_params = [:name, :slug, :source_of_data, :location_match_type]
+    permitted_params = [:name, :slug, :source_of_data, :location_match_type, :local_authority_hierarchy_match_type]
     permitted_params << :data_file if %w(create new).include? action_name.to_s
     params.
       require(:service).

--- a/test/functional/admin/services_controller_test.rb
+++ b/test/functional/admin/services_controller_test.rb
@@ -1,5 +1,27 @@
 require 'test_helper'
 
 class Admin::ServicesControllerTest < ActionController::TestCase
-  # TODO: Write some controller tests here
+  test "should create service" do
+    as_logged_in_user do
+      service_params = {
+        "name" => "Register Offices",
+        "slug" => "register-offices",
+        "location_match_type" => "local_authority",
+        "local_authority_hierarchy_match_type" => "county"
+      }
+
+      post :create, service: service_params
+      assert_response :redirect
+
+      assert_equal 1, Service.count
+
+      service = Service.last
+      assert_equal "Register Offices", service.name
+      assert_equal "register-offices", service.slug
+      assert_equal "local_authority", service.location_match_type
+      assert_equal "county", service.local_authority_hierarchy_match_type
+    end
+  end
+
+  # TODO: Write more controller tests here
 end


### PR DESCRIPTION
ServicesController was not permitting the `local_authority_hierarchy_match_type` param, which meant we could not create a Service with 'County'-level lookup for 'Local Authority' lookups in the Admin UI.