### PR TITLE
Remove calls to mysociety mapit

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -1,0 +1,19 @@
+Copyright (C) 2014 Crown copyright (Government Digital Service)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,40 @@ so it can be tested using a variety of other tools.
 
 There is a simple JSON API for integrating the data with other applications.
 
-## Application Details
+## Nomenclature
+
+- **Services**: Represent a distinct type of location (e.g. Register Offices)
+- **Datasets**: Services can have many datasets, which are collections of Places. Only one Data Set will be "active" at any given time.
+- **Places**: Geocoded data of individual locations which belong to a Dataset.
+
+## Technical documentation
 
 Imminence is a Ruby on Rails application backed by a MongoDB database.
+
+### Dependencies
+
+- [alphagov/mapit](https://github.com/alphagov/mapit) - provides postcode lookups
+
+### Running the application
+
+From within the app root directory:
+
+`./startup.sh`
+
+Note that you will have to have GOV.UK Mapit running locally.
+
+In the GOV.UK DEV VM from the 'development' directory:
+
+`bowl imminence`
+
+Note that the app uses a local version of [GOV.UK Mapit](https://github.com/alphagov/mapit), therefore a valid dataset will have to be loaded for Mapit, otherwise postcode lookups will not succeed. This is part of the standard GOV.UK data replication steps.
+
+### Running the test suite
+
+`bundle exec rake`
+
+`bundle exec govuk-lint-ruby app test lib`
+
+## Licence
+
+[MIT License](LICENCE)

--- a/config/initializers/mapit.rb
+++ b/config/initializers/mapit.rb
@@ -1,9 +1,4 @@
 require 'gds_api/mapit'
 require 'plek'
 
-# In development, use MySociety's mapit install, as we won't normally have mapit running.
-if Rails.env.development?
-  Imminence.mapit_api = GdsApi::Mapit.new( ENV['MAPIT_ENDPOINT'] || 'http://mapit.mysociety.org/')
-else
-  Imminence.mapit_api = GdsApi::Mapit.new( Plek.current.find('mapit') )
-end
+Imminence.mapit_api = GdsApi::Mapit.new(Plek.current.find('mapit'))


### PR DESCRIPTION
As we now have our own mapit app running as part of the development stack, we can stop making requests to mysociety's mapit.

For https://trello.com/c/T1Md03fc/381-use-our-mapit-in-dev-consistently