### PR TITLE
Stop including a slug with the area API responses

### DIFF
--- a/app/presenters/areas_presenter.rb
+++ b/app/presenters/areas_presenter.rb
@@ -31,7 +31,6 @@ private
 
   def area_attrs(area)
     {
-      "slug" => area["name"].parameterize,
       "name" => area["name"],
       "country_name" => area["country_name"],
       "type" => area["type"],

--- a/test/integration/areas_by_postcode_test.rb
+++ b/test/integration/areas_by_postcode_test.rb
@@ -11,6 +11,7 @@ class AreasByPostcodeTest < ActionDispatch::IntegrationTest
     mapit_location_response = OpenStruct.new(response: mapit_areas_response)
     Imminence.mapit_api.stubs(:location_for_postcode).returns(mapit_location_response)
   end
+
   test "areas are returned for valid types" do
     visit "/areas/WC2B%206SE.json"
 
@@ -20,11 +21,11 @@ class AreasByPostcodeTest < ActionDispatch::IntegrationTest
     assert_equal 2, parsed_response["total"]
     results = parsed_response["results"]
 
-    assert_equal "westminster-city-council", results.first["slug"]
+    assert results.none? { |r| r.key?("slug") }
+
     assert_equal "Westminster City Council", results.first["name"]
     assert_equal "England", results.first["country_name"]
     assert_equal "LBO", results.first["type"]
-    assert_equal "london", results.second["slug"]
     assert_equal "London", results.second["name"]
     assert_equal "England", results.second["country_name"]
     assert_equal "EUR", results.second["type"]

--- a/test/integration/areas_by_type_test.rb
+++ b/test/integration/areas_by_type_test.rb
@@ -9,6 +9,7 @@ class AreasByTypeTest < ActionDispatch::IntegrationTest
     })
     Imminence.mapit_api.stubs(:areas_for_type).returns(mapit_response)
   end
+
   test "areas are returned for valid types" do
     visit "/areas/EUR.json"
 
@@ -18,15 +19,14 @@ class AreasByTypeTest < ActionDispatch::IntegrationTest
     assert_equal 3, parsed_response["total"]
     results = parsed_response["results"]
 
-    assert_equal "london", results.first["slug"]
+    assert results.none? { |r| r.key?("slug") }
+
     assert_equal "London", results.first["name"]
     assert_equal "England", results.first["country_name"]
     assert_equal "EUR", results.first["type"]
-    assert_equal "yorkshire-and-the-humber", results.second["slug"]
     assert_equal "Yorkshire and the Humber", results.second["name"]
     assert_equal "England", results.second["country_name"]
     assert_equal "EUR", results.second["type"]
-    assert_equal "scotland", results.last["slug"]
     assert_equal "Scotland", results.last["name"]
     assert_equal "Scotland", results.last["country_name"]
     assert_equal "EUR", results.last["type"]

--- a/test/unit/presenters/areas_presenter_test.rb
+++ b/test/unit/presenters/areas_presenter_test.rb
@@ -40,7 +40,7 @@ class AreasPresenterTest < ActiveSupport::TestCase
       end
 
       should "expose the correct data" do
-        assert_equal "westminster-city-council", @result["slug"]
+        refute @result.key?('slug')
         assert_equal "Westminster City Council", @result["name"]
         assert_equal "England", @result["country_name"]
         assert_equal "LBO", @result["type"]
@@ -56,7 +56,7 @@ class AreasPresenterTest < ActiveSupport::TestCase
       end
 
       should "expose the correct data" do
-        assert_equal "london", @result["slug"]
+        refute @result.key?('slug')
         assert_equal "London", @result["name"]
         assert_equal "England", @result["country_name"]
         assert_equal "EUR", @result["type"]


### PR DESCRIPTION
The slugs are made by parameterizing the names we get from mapit and
these aren't stable identifiers.  We could use the govuk_slug that we've
recently added, but we only have those for councils and this API also
returns european parliament areas for which we don't have govuk_slugs.

For: https://trello.com/c/PKAohBzb/468-stop-adding-slugs-to-areas-returned-from-mapit-by-imminence-2

There are follow up PRs on other apps to tidy up the fallout from this change.