### PR TITLE
Correct our handling of MapIt responses

### DIFF
--- a/app/controllers/areas_controller.rb
+++ b/app/controllers/areas_controller.rb
@@ -28,13 +28,13 @@ private
 
   def fetch_areas_for_type(type)
     Imminence.mapit_api.areas_for_type(type)
-  rescue GdsApi::HTTPNotFound, GdsApi::HTTPGone
+  rescue GdsApi::HTTPClientError
     nil
   end
 
   def fetch_location_for_postcode(postcode)
     Imminence.mapit_api.location_for_postcode(postcode)
-  rescue GdsApi::HTTPNotFound, GdsApi::HTTPGone
+  rescue GdsApi::HTTPClientError
     nil
   end
 end

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -114,7 +114,7 @@ class Place
         longitude: result.lon
       )
     end
-  rescue GdsApi::HTTPNotFound, GdsApi::HTTPGone
+  rescue GdsApi::HTTPClientError
     self.geocode_error = "#{self.postcode} not found for #{self.full_address}"
   rescue => e
     error = "Error geocoding place #{self.postcode} : #{e.message}"

--- a/lib/mapit_api.rb
+++ b/lib/mapit_api.rb
@@ -9,7 +9,7 @@ module MapitApi
     location_data = Imminence.mapit_api.location_for_postcode(postcode)
     raise ValidPostcodeNoLocation if location_data.lat.nil? || location_data.lon.nil?
     location_data
-  rescue GdsApi::HTTPNotFound, GdsApi::HTTPGone
+  rescue GdsApi::HTTPClientError
     raise InvalidPostcodeError
   end
 

--- a/test/integration/areas_by_postcode_test.rb
+++ b/test/integration/areas_by_postcode_test.rb
@@ -9,6 +9,10 @@ class AreasByPostcodeTest < ActionDispatch::IntegrationTest
       { "name" => "Westminster City Council", "type" => "LBO" },
       { "name" => "London", "type" => "EUR" }
     ])
+
+    mapit_does_not_have_a_postcode("MISSING_POSTCODE")
+
+    mapit_does_not_have_a_bad_postcode("NOT_A_POSTCODE")
   end
 
   test "areas are returned for valid types" do
@@ -26,5 +30,23 @@ class AreasByPostcodeTest < ActionDispatch::IntegrationTest
     assert_equal "LBO", results.first["type"]
     assert_equal "London", results.second["name"]
     assert_equal "EUR", results.second["type"]
+  end
+
+  test "missing postcodes are presented correctly" do
+    visit "/areas/MISSING_POSTCODE.json"
+
+    parsed_response = JSON.parse(page.source)
+
+    assert_equal 404, parsed_response["_response_info"]["status"]
+    assert_equal 0, parsed_response["total"]
+  end
+
+  test "invalid postcodes are presented correctly" do
+    visit "/areas/NOT_A_POSTCODE.json"
+
+    parsed_response = JSON.parse(page.source)
+
+    assert_equal 404, parsed_response["_response_info"]["status"]
+    assert_equal 0, parsed_response["total"]
   end
 end

--- a/test/integration/places_api_test.rb
+++ b/test/integration/places_api_test.rb
@@ -140,10 +140,17 @@ class PlacesAPITest < ActionDispatch::IntegrationTest
         assert_equal @place2.name, data[0]['name']
       end
 
-      should "return a 400 for an invalid postcode" do
+      should "return a 400 for a missing postcode" do
         mapit_does_not_have_a_postcode('N11 3QQ')
 
         get "/places/#{@service.slug}.json?postcode=N11+3QQ"
+        assert_equal 400, last_response.status
+      end
+
+      should "return a 400 for an invalid postcode" do
+        mapit_does_not_have_a_bad_postcode('N1')
+
+        get "/places/#{@service.slug}.json?postcode=N1"
         assert_equal 400, last_response.status
       end
     end


### PR DESCRIPTION
MapIt's postcode route returns the following statuses:
 - `200` if a postcode exists
 - `404` if it is a valid postcode but MapIt doesn't know about it
 - `400` if it is not a valid postcode ([postcode validity is handled here][1])

We currently handle `404`/`410` errors but MapIt doesn't return `410`s and does return `400`s.  This amends the exception handling to include all `4xx` errors.

We don't treat missing postcodes (that is seemingly valid postcodes that we don't have in our dataset) any differently from invalid postcodes at the moment.  (We do for [some formats][2] in Frontend, but not `places`)   

[1]: https://github.com/alphagov/mapit/blob/c8afd5ea52446a64ae5d37b52f3ada9d2430901e/mapit_gb/countries.py#L66
[2]: https://github.com/alphagov/frontend/blob/eb916bbb30bf1c24faec46291cb24147deae3445/app/controllers/root_controller.rb#L236L247