### PR TITLE
Fix cucumber rake issues

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,2 @@
+---
+BUNDLE_DISABLE_EXEC_LOAD: "true"

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .bundle
+!.bundle/config
 db/*.sqlite3
 log/*.log
 tmp/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 
 REPOSITORY = 'imminence'
 
-node {
+node('mongodb-2.4') {
   def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
 
   try {


### PR DESCRIPTION
Running bundle exec rake cucumber fails with versions of Bundler after 1.13 unless BUNDLE_DISABLE_EXEC_LOAD is set to true. We are currently using Bundler 1.14.5 ([cf. govuk-puppet](https://github.com/alphagov/govuk-puppet/blob/580f9fd2ecdd012ad8ae16332bd8a3ad9adf2356/modules/govuk_rbenv/manifests/all.pp#L40)) so we'd need to set BUNDLE_DISABLE_EXEC_LOAD to true for all repos that use cucumber.

The alternative would be to set this to true in govuk_puppet, but that would affect all repos regardless of whether they use cucumber, and there might be performance implications: http://bundler.io/man/bundle-exec.1.html#Loading .

This also involves not gitignoring .bundle anymore, I am unsure whether that might clash with any puppet config.

https://trello.com/c/rxJTEuwW/27-fix-imminence-issues