### PR TITLE
Remove reference to business-support-api

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,8 +12,6 @@ Rails.application.routes.draw do
 
   # This list should stay in sync with Publisher's Area::AREA_TYPES
   # https://github.com/alphagov/publisher/blob/master/app/models/area.rb#L7-L10
-  # and Business Support API's Scheme::WHITELISTED_AREA_CODES list:
-  # https://github.com/alphagov/business-support-api/blob/master/app/models/scheme.rb#L16-L18
   get '/areas/:area_type', :to => 'areas#index', :constraints => { :area_type => /EUR|CTY|DIS|LBO|LGD|MTD|UTA|COI/ }
   get '/areas/:postcode', :to => 'areas#search', :constraints => { :postcode => /[\w% ]+/ }
 


### PR DESCRIPTION
This commit removes the reference to the `business-support-api` which has now been retired.