### PR TITLE
Get Redis host from env var.

### DIFF
--- a/config/redis.yml
+++ b/config/redis.yml
@@ -11,6 +11,6 @@ test:
   namespace: imminence-test
 
 production:
-  host: redis-2.backend
+  host: <%= ENV["REDIS_HOST"] %>
   port: 6379
   namespace: imminence


### PR DESCRIPTION
This was inadvertently hard-coded when this app was moved to 12 factor.