### PR TITLE
Bump logstasher to 1.2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem 'kaminari-actionview'
 gem 'bootstrap-kaminari-views', '~> 0.0.3'
 
 gem 'state_machines-mongoid', '~> 0.1.1'
-gem 'logstasher', '0.4.8'
+gem 'logstasher', '~> 1.2.1'
 
 gem 'sass-rails', '~> 5.0'
 gem 'uglifier', '2.7.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,9 +180,11 @@ GEM
     launchy (2.4.3)
       addressable (~> 2.3)
     link_header (0.0.8)
-    logstash-event (1.1.5)
-    logstasher (0.4.8)
-      logstash-event (~> 1.1.0)
+    logstash-event (1.2.02)
+    logstasher (1.2.1)
+      activesupport (>= 4.0)
+      logstash-event (~> 1.2.0)
+      request_store
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     lrucache (0.1.4)
@@ -294,6 +296,7 @@ GEM
     redis (3.3.3)
     redis-namespace (1.5.3)
       redis (~> 3.0, >= 3.0.4)
+    request_store (1.3.2)
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
@@ -409,7 +412,7 @@ DEPENDENCIES
   kaminari-actionview
   kaminari-mongoid
   launchy
-  logstasher (= 0.4.8)
+  logstasher (~> 1.2.1)
   minitest-reporters
   mocha (~> 1.1.0)
   mongoid


### PR DESCRIPTION
We want to get all the apps working on a consistent logstasher version so that
it sends similarly formatted json logs to kibana.