### PR TITLE
Bump govuk_app_config

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source 'http://rubygems.org'
 gem 'plek', '~> 1.11.0'
 
 gem 'rails', '5.0.2'
-gem 'unicorn', '4.3.1'
 
 gem "mongoid"
 gem "mongoid_rails_migrations"
@@ -13,7 +12,6 @@ gem 'formtastic'
 gem 'formtastic-bootstrap'
 
 gem 'gds-api-adapters', '~> 51.0.0'
-gem 'statsd-ruby', '1.4.0', require: 'statsd'
 
 if ENV['BUNDLE_DEV']
   gem 'gds-sso', path: '../gds-sso'
@@ -21,7 +19,7 @@ else
   gem 'gds-sso', '~> 13.0.0'
 end
 
-gem 'govuk_app_config', '~> 0.2.0'
+gem 'govuk_app_config', '~> 1.2'
 gem "govuk_sidekiq", "~> 2.0.0"
 
 gem 'responders', '~> 2.0'
@@ -32,7 +30,6 @@ gem 'bootstrap-kaminari-views', '~> 0.0.3'
 
 gem 'state_machines', '~> 0.4.0'
 gem 'state_machines-mongoid', '~> 0.1.1'
-gem 'logstasher', '~> 1.2.1'
 
 gem 'sass-rails', '~> 5.0'
 gem 'uglifier', '2.7.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,9 +142,11 @@ GEM
       bootstrap-sass (= 3.3.5.1)
       jquery-rails (~> 4.1.1)
       rails (>= 3.2.0)
-    govuk_app_config (0.2.0)
-      sentry-raven (~> 2.6.3)
+    govuk_app_config (1.2.1)
+      logstasher (~> 1.2.2)
+      sentry-raven (~> 2.7.1)
       statsd-ruby (~> 1.4.0)
+      unicorn (~> 5.4.0)
     govuk_sidekiq (2.0.0)
       gds-api-adapters (>= 19.1.0)
       redis-namespace (~> 1.5.2)
@@ -186,7 +188,7 @@ GEM
     kaminari-mongoid (1.0.1)
       kaminari-core (~> 1.0)
       mongoid
-    kgio (2.11.0)
+    kgio (2.11.1)
     launchy (2.4.3)
       addressable (~> 2.3)
     link_header (0.0.8)
@@ -311,7 +313,8 @@ GEM
     redis (3.3.5)
     redis-namespace (1.5.3)
       redis (~> 3.0, >= 3.0.4)
-    request_store (1.3.2)
+    request_store (1.4.0)
+      rack (>= 1.4)
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
@@ -347,7 +350,7 @@ GEM
     sdoc (0.4.2)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
-    sentry-raven (2.6.3)
+    sentry-raven (2.7.1)
       faraday (>= 0.7.6, < 1.0)
     shoulda-context (1.2.2)
     sidekiq (4.2.10)
@@ -395,9 +398,8 @@ GEM
       unf_ext
     unf_ext (0.0.7.4)
     unicode-display_width (1.3.0)
-    unicorn (4.3.1)
+    unicorn (5.4.0)
       kgio (~> 2.6)
-      rack
       raindrops (~> 0.7)
     warden (1.2.7)
       rack (>= 1.0)
@@ -429,13 +431,12 @@ DEPENDENCIES
   gds-sso (~> 13.0.0)
   govuk-lint (= 3.6.0)
   govuk_admin_template (= 6.0.0)
-  govuk_app_config (~> 0.2.0)
+  govuk_app_config (~> 1.2)
   govuk_sidekiq (~> 2.0.0)
   inherited_resources
   kaminari-actionview
   kaminari-mongoid
   launchy
-  logstasher (~> 1.2.1)
   minitest-reporters
   mocha (~> 1.3.0)
   mongoid
@@ -453,9 +454,7 @@ DEPENDENCIES
   simplecov-rcov (~> 0.2.3)
   state_machines (~> 0.4.0)
   state_machines-mongoid (~> 0.1.1)
-  statsd-ruby (= 1.4.0)
   uglifier (= 2.7.2)
-  unicorn (= 4.3.1)
   webmock (~> 3.2.1)
 
 BUNDLED WITH

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,10 +46,6 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
-  # Use the lowest log level to ensure availability of diagnostic information
-  # when problems arise.
-  config.log_level = :info
-
   # Prepend all log lines with the following tags.
   # config.log_tags = [ :subdomain, :uuid ]
 
@@ -71,23 +67,6 @@ Rails.application.configure do
 
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify
-
-  # Use default logging formatter so that PID and timestamp are not suppressed.
-  config.log_formatter = ::Logger::Formatter.new
-
-  # Enable JSON-style logging
-  config.logstasher.enabled = true
-  config.logstasher.logger = Logger.new("#{Rails.root}/log/#{Rails.env}.json.log")
-  config.logstasher.supress_app_log = true
-  # Use a different logger for distributed setups.
-  # require 'syslog/logger'
-  # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
-
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger           = ActiveSupport::Logger.new(STDOUT)
-    logger.formatter = config.log_formatter
-    config.logger = ActiveSupport::TaggedLogging.new(logger)
-  end
 
   # Do not dump schema after migrations.
   # config.active_record.dump_schema_after_migration = false

--- a/config/initializers/logstasher.rb
+++ b/config/initializers/logstasher.rb
@@ -1,9 +1,0 @@
-if Object.const_defined?('LogStasher') && LogStasher.enabled
-  LogStasher.add_custom_fields do |fields|
-    # Mirrors Nginx request logging, e.g GET /path/here HTTP/1.1
-    fields[:request] = "#{request.request_method} #{request.fullpath} #{request.headers['SERVER_PROTOCOL']}"
-    # Pass the request id to logging
-    fields[:govuk_request_id] = request.headers['GOVUK-Request-Id']
-    fields[:varnish_id] = request.headers['X-Varnish']
-  end
-end


### PR DESCRIPTION
This means we should remove the direct dependencies on unicorn, statsd and
logstasher as they are now controlled by the gem dependencies.

We can also remove all the logging configuration as there is nothing unique
set here that is not in the gem.

The default logging level is set to `:info` in the govuk_app_config gem