### PR TITLE
Require govuk_unicorn in config/unicorn.rb

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,3 +1,3 @@
-require "govuk_app_config"
+require "govuk_app_config/govuk_unicorn"
 GovukUnicorn.configure(self)
 working_directory File.dirname(File.dirname(__FILE__))


### PR DESCRIPTION
This is the suggested form for config/unicorn.rb as of govuk_app_config 1.3.2
as it avoids some stdout/stderr manipulation.