### PR TITLE
Use external URLs for Signon

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,7 +18,7 @@
 <% end %>
 
 <% content_for :navbar_right do %>
-  <%= link_to current_user.name, Plek.current.find('signon') %>
+  <%= link_to current_user.name, Plek.new.external_url_for('signon') %>
   &bull; <%= link_to 'Sign out', gds_sign_out_path %>
 <% end %>
 

--- a/config/initializers/gds-sso.rb
+++ b/config/initializers/gds-sso.rb
@@ -2,5 +2,5 @@ GDS::SSO.config do |config|
   config.user_model   = "User"
   config.oauth_id     = ENV["OAUTH_ID"] || "abcdefghjasndjkasndimminence"
   config.oauth_secret = ENV["OAUTH_SECRET"] || "secret"
-  config.oauth_root_url = Plek.current.find("signon")
+  config.oauth_root_url = Plek.new.external_url_for("signon")
 end


### PR DESCRIPTION
This makes imminence work in environments where the external URLs for
applications are different to the internal URLs.