### PR TITLE
Run dataset duplication as a background job

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,1 +1,14 @@
+//= require jquery
+//= require bootstrap
 //= require 'modules/form-value-dependent'
+
+
+/**
+ * Activate the tab specified by the location hash
+ */
+$(document).ready(function () {
+  var $tabToActivate = $('.nav-tabs a[href="' + window.location.hash + '"]');
+  if ($tabToActivate.length) {
+    $tabToActivate.tab('show');
+  }
+});

--- a/app/controllers/admin/data_sets_controller.rb
+++ b/app/controllers/admin/data_sets_controller.rb
@@ -18,7 +18,7 @@ class Admin::DataSetsController < InheritedResources::Base
 
   def duplicate
     DuplicateDataSetWorker.perform_async(resource.service.id.to_s, resource.id.to_s)
-    flash[:success] = "Your request for a duplicate data set (version #{resource.version}) is being processed. This can take a few minutes."
+    flash[:success] = "Your request for a duplicate of data set version #{resource.version} is being processed. This can take a few minutes. Please refresh this page."
     redirect_to "#{admin_service_path(service)}#history"
   end
 

--- a/app/controllers/admin/data_sets_controller.rb
+++ b/app/controllers/admin/data_sets_controller.rb
@@ -17,9 +17,9 @@ class Admin::DataSetsController < InheritedResources::Base
   end
 
   def duplicate
-    duplicated_data_set = resource.duplicate
-    flash[:success] = "Version #{duplicated_data_set.version} has been created."
-    redirect_to admin_service_data_set_path(service, duplicated_data_set)
+    DuplicateDataSetWorker.perform_async(resource.service.id.to_s, resource.id.to_s)
+    flash[:success] = "Your request for a duplicate data set (version #{resource.version}) is being processed. This can take a few minutes."
+    redirect_to admin_service_path(service)
   end
 
   def activate

--- a/app/controllers/admin/data_sets_controller.rb
+++ b/app/controllers/admin/data_sets_controller.rb
@@ -19,7 +19,7 @@ class Admin::DataSetsController < InheritedResources::Base
   def duplicate
     DuplicateDataSetWorker.perform_async(resource.service.id.to_s, resource.id.to_s)
     flash[:success] = "Your request for a duplicate data set (version #{resource.version}) is being processed. This can take a few minutes."
-    redirect_to admin_service_path(service)
+    redirect_to "#{admin_service_path(service)}#history"
   end
 
   def activate

--- a/app/views/admin/services/_history.html.erb
+++ b/app/views/admin/services/_history.html.erb
@@ -14,6 +14,8 @@
             <span class="label label-default">Archiving</span>
           <% elsif set.active? %>
             <span class="label label-success">Active</span>
+          <% elsif set.duplicating? %>
+            <span class="label label-info">Duplicating</span>
           <% else %>
             <span class="label label-default">Inactive</span>
           <% end %>

--- a/app/workers/duplicate_data_set_worker.rb
+++ b/app/workers/duplicate_data_set_worker.rb
@@ -1,0 +1,8 @@
+class DuplicateDataSetWorker
+  include Sidekiq::Worker
+
+  def perform(service_id, data_set_id)
+    service = Service.find(service_id)
+    service.data_sets.where("id" => data_set_id).first.duplicate
+  end
+end

--- a/features/data_sets.feature
+++ b/features/data_sets.feature
@@ -45,8 +45,8 @@ Feature: Managing data sets
       And I visit the history tab
       And I duplicate the most recent data set
 
-    Then I should be on the page for the latest data set for the "Register Offices" service
-      And I should see that there are now 3 data sets
+    Then I should be on the page for the "Register Offices" service
+      And I should see that a duplicating job was enqueued for data set version 2
 
   Scenario: Editing an inactive data set
     Given I have previously created the "Register Offices" service

--- a/features/step_definitions/data_set_steps.rb
+++ b/features/step_definitions/data_set_steps.rb
@@ -94,11 +94,6 @@ Then /^show me the page$/ do
   save_and_open_page
 end
 
-Then /^I should be on the page for the latest data set for the "(.*?)" service$/ do |name|
-  current_path = URI.parse(current_url).path
-  assert_equal path_for_latest_data_set_for_service(name), current_path
-end
-
 Then /^I should see an indication that my data set is awaiting processing$/ do
   assert page.has_content?("Places data is currently being processed")
 end
@@ -109,6 +104,10 @@ end
 
 Then /^I should see an indication that my data set is empty$/ do
   assert page.has_content?("No places are associated with this set. The imported data could be in the wrong format.")
+end
+
+Then /^I should be on the page for the latest data set for the "(.*?)" service$/ do |name|
+  assert_equal path_for_latest_data_set_for_service(name), current_path
 end
 
 Then /^I should see that there are now (\d+) data sets$/ do |count|
@@ -160,4 +159,8 @@ end
 
 Then /^I should not see the first data set$/ do
   assert ! page.has_content?("Version 1")
+end
+
+Then("I should see that a duplicating job was enqueued for data set version {int}") do |int|
+  assert page.has_content?("Your request for a duplicate data set (version #{int}) is being processed. This can take a few minutes.")
 end

--- a/features/step_definitions/data_set_steps.rb
+++ b/features/step_definitions/data_set_steps.rb
@@ -162,5 +162,5 @@ Then /^I should not see the first data set$/ do
 end
 
 Then("I should see that a duplicating job was enqueued for data set version {int}") do |int|
-  assert page.has_content?("Your request for a duplicate data set (version #{int}) is being processed. This can take a few minutes.")
+  assert page.has_content?("Your request for a duplicate of data set version #{int} is being processed. This can take a few minutes.")
 end

--- a/test/functional/admin/data_sets_controller_test.rb
+++ b/test/functional/admin/data_sets_controller_test.rb
@@ -122,7 +122,7 @@ class Admin::DataSetsControllerTest < ActionController::TestCase
           assert_equal @service.id.to_s, job['args'].first
           assert_equal @service.latest_data_set.id.to_s, job['args'].second
           assert_equal 1, DuplicateDataSetWorker.jobs.count
-          assert_redirected_to admin_service_path(@service)
+          assert_redirected_to "#{admin_service_path(@service)}#history"
         end
       end
     end

--- a/test/functional/admin/data_sets_controller_test.rb
+++ b/test/functional/admin/data_sets_controller_test.rb
@@ -112,5 +112,19 @@ class Admin::DataSetsControllerTest < ActionController::TestCase
         end
       end
     end
+
+    context "when duplicating a data set" do
+      should "create a background job for duplicating the dataset" do
+        as_logged_in_user do
+          FactoryBot.create(:place)
+          post :duplicate, params: { service_id: @service.id, id: @service.latest_data_set.id }
+          job = DuplicateDataSetWorker.jobs.last
+          assert_equal @service.id.to_s, job['args'].first
+          assert_equal @service.latest_data_set.id.to_s, job['args'].second
+          assert_equal 1, DuplicateDataSetWorker.jobs.count
+          assert_redirected_to admin_service_path(@service)
+        end
+      end
+    end
   end
 end

--- a/test/integration/admin/data_set_create_edit_duplicate_test.rb
+++ b/test/integration/admin/data_set_create_edit_duplicate_test.rb
@@ -111,5 +111,20 @@ class DataSetCreateEditTest < ActionDispatch::IntegrationTest
       assert_equal 51.599123456789, place.override_lat
       assert_equal 0.10033123456789, place.override_lng
     end
+
+    should "create a duplicate data_set" do
+      FactoryBot.create(:place)
+
+      visit "/admin/services/#{@service.id}"
+
+      within "#new-data" do
+        click_on "Duplicate most recent data set (Version 1)"
+      end
+
+      @service.reload
+      assert_equal 2, @service.data_sets.count
+      ds = @service.latest_data_set
+      assert_equal 1, ds.places.count
+    end
   end
 end

--- a/test/unit/data_set_test.rb
+++ b/test/unit/data_set_test.rb
@@ -422,5 +422,30 @@ class DataSetTest < ActiveSupport::TestCase
         assert_equal [], @data_set.places_for_postcode("BT1 5GS").to_a
       end
     end
+
+    context "duplicating a data set" do
+      setup do
+        DataSet.any_instance.stubs(duplicated: nil)
+        service = FactoryBot.create(:service)
+        data_set = service.latest_data_set
+        @dupe = data_set.duplicate
+      end
+
+      should "mark the state of the duplicate data set as 'duplicating'" do
+        assert_equal "duplicating", @dupe.state
+      end
+    end
+
+    context "duplicated data set" do
+      setup do
+        service = FactoryBot.create(:service)
+        data_set = service.latest_data_set
+        @dupe = data_set.duplicate
+      end
+
+      should "transition from 'duplicating' to 'unarchived' once finished" do
+        assert_equal %w(duplicating unarchived), @dupe.previous_changes["state"]
+      end
+    end
   end
 end


### PR DESCRIPTION
Large dataset duplication requests are either timing out or incomplete, copying only some of the data. This adds a Sidekiq worker to allow the duplication to run asynchronously. The user will see a flash message saying their duplicate data set request is being processed.

![screenshot from 2018-06-27 15-58-00](https://user-images.githubusercontent.com/93511/41982305-00dd2b42-7a23-11e8-9a4c-e96e8f57e9e4.png)



Paired with @steventux 

https://trello.com/c/Sbbp0Vi6/264-imminence-not-duplicating-data-sets