### PR TITLE
Replace poltergeist with govuk test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ group :test do
   gem 'cucumber-rails', require: false
   gem 'capybara'
   gem 'database_cleaner'
+  gem 'govuk_test'
   gem 'simplecov', '~> 0.16.1', require: false
   gem 'simplecov-rcov', '~> 0.2.3', require: false
   gem 'factory_bot_rails', '~> 4.11.0'
@@ -54,7 +55,6 @@ group :test do
   gem 'launchy'
   gem 'shoulda-context'
   gem 'mocha', '~> 1.7.0', require: false
-  gem 'poltergeist', '~> 1.18.1'
   gem 'webmock', '~> 3.4.2', require: false
   gem 'rails-controller-testing'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,8 @@ GEM
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     ansi (1.5.0)
+    archive-zip (0.11.0)
+      io-like (~> 0.3.0)
     arel (9.0.0)
     ast (2.4.0)
     autoprefixer-rails (8.3.0)
@@ -65,12 +67,16 @@ GEM
       rack (>= 1.6.0)
       rack-test (>= 0.6.3)
       xpath (~> 3.1)
+    childprocess (0.9.0)
+      ffi (~> 1.0, >= 1.0.11)
+    chromedriver-helper (1.2.0)
+      archive-zip (~> 0.10)
+      nokogiri (~> 1.8)
     ci_reporter (2.0.0)
       builder (>= 2.1.2)
     ci_reporter_minitest (1.0.0)
       ci_reporter (~> 2.0)
       minitest (~> 5.0)
-    cliver (0.3.2)
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
     connection_pool (2.2.2)
@@ -157,6 +163,11 @@ GEM
       sidekiq (>= 5, < 6)
       sidekiq-logging-json (~> 0.0)
       sidekiq-statsd (~> 0.1)
+    govuk_test (0.1.0)
+      capybara
+      chromedriver-helper
+      puma
+      selenium-webdriver
     has_scope (0.7.2)
       actionpack (>= 4.1)
       activesupport (>= 4.1)
@@ -171,6 +182,7 @@ GEM
       has_scope (~> 0.6)
       railties (>= 4.2, < 5.3)
       responders
+    io-like (0.3.0)
     jquery-rails (4.3.1)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -263,15 +275,12 @@ GEM
     parser (2.5.0.5)
       ast (~> 2.4.0)
     plek (2.1.1)
-    poltergeist (1.18.1)
-      capybara (>= 2.1, < 4)
-      cliver (~> 0.3.1)
-      websocket-driver (>= 0.2.0)
     powerpack (0.1.1)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     public_suffix (3.0.3)
+    puma (3.12.0)
     rack (2.0.5)
     rack-cache (1.8.0)
       rack (>= 0.4)
@@ -336,6 +345,7 @@ GEM
     rubocop-rspec (1.19.0)
       rubocop (>= 0.51.0)
     ruby-progressbar (1.10.0)
+    rubyzip (1.2.2)
     safe_yaml (1.0.4)
     sass (3.5.6)
       sass-listen (~> 4.0.0)
@@ -353,6 +363,9 @@ GEM
       sass (~> 3.5.5)
     sdoc (1.0.0)
       rdoc (>= 5.0)
+    selenium-webdriver (3.14.0)
+      childprocess (~> 0.5)
+      rubyzip (~> 1.2)
     sentry-raven (2.7.4)
       faraday (>= 0.7.6, < 1.0)
     shoulda-context (1.2.2)
@@ -435,6 +448,7 @@ DEPENDENCIES
   govuk_admin_template (= 6.6.0)
   govuk_app_config (~> 1.8)
   govuk_sidekiq (~> 3.0.2)
+  govuk_test
   inherited_resources
   kaminari-actionview
   kaminari-mongoid
@@ -444,7 +458,6 @@ DEPENDENCIES
   mongoid
   mongoid_rails_migrations
   plek (~> 2.1.1)
-  poltergeist (~> 1.18.1)
   pry
   rails (= 5.2.0)
   rails-controller-testing
@@ -460,4 +473,4 @@ DEPENDENCIES
   webmock (~> 3.4.2)
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/features/support/govuk_test.rb
+++ b/features/support/govuk_test.rb
@@ -1,0 +1,1 @@
+GovukTest.configure

--- a/features/support/poltergeist.rb
+++ b/features/support/poltergeist.rb
@@ -1,2 +1,0 @@
-require 'capybara/poltergeist'
-Capybara.javascript_driver = :poltergeist

--- a/test/factories/places_factories.rb
+++ b/test/factories/places_factories.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :service do
-    name "Important Government Service"
+    name { "Important Government Service" }
     sequence(:slug) {|n| "important-government-service-#{n}"}
-    source_of_data "Somewhere beyond the sea"
+    source_of_data { "Somewhere beyond the sea" }
   end
 
   factory :place do
@@ -13,11 +13,11 @@ FactoryBot.define do
 
     service_slug { (Service.first || create(:service)).slug }
     data_set_version { Service.where(slug: service_slug).first.active_data_set_version }
-    name "CosaNostra Pizza #3569"
+    name { "CosaNostra Pizza #3569" }
     sequence(:address1) {|n| "#{n} Vista Road" }
-    town "Los Angeles"
-    postcode "WC2B 6NH"
-    phone "01234 567890"
+    town { "Los Angeles" }
+    postcode { "WC2B 6NH" }
+    phone { "01234 567890" }
     location { Point.new(latitude: latitude, longitude: longitude) }
   end
 end

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -26,5 +26,4 @@ class ActionDispatch::IntegrationTest
   end
 end
 
-require 'capybara/poltergeist'
-Capybara.javascript_driver = :poltergeist
+GovukTest.configure


### PR DESCRIPTION
https://trello.com/c/0QzuQFMb/415-epic-switch-app-test-suites-from-poltergeist-to-headless-chrome-using-govuktest

Poltergeist is no longer maintained so replace with Capybara::RackTest and Selenium headless chrome drivers.