### PR TITLE
Switch to the :json cookie serializer

### DIFF
--- a/config/initializers/cookies_serializer.rb
+++ b/config/initializers/cookies_serializer.rb
@@ -2,4 +2,4 @@
 
 # Specify a serializer for the signed and encrypted cookie jars.
 # Valid options are :json, :marshal, and :hybrid.
-Rails.application.config.action_dispatch.cookies_serializer = :hybrid
+Rails.application.config.action_dispatch.cookies_serializer = :json


### PR DESCRIPTION
As this avoids security issues with the :marshal serialization
approach. The :hybrid approach will have migrated the old cookies to
the new JSON approach, so this shouldn't cause any issues.