### PR TITLE
Use `rubocop-govuk` instead of `govuk-lint`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,3 +2,6 @@ inherit_gem:
   rubocop-govuk:
     - config/default.yml
     - config/rails.yml
+
+Rails/RakeEnvironment:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,4 @@
-Rails:
-  Enabled: true
+inherit_gem:
+  rubocop-govuk:
+    - config/default.yml
+    - config/rails.yml

--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ gem "uglifier", "4.2.0"
 gem "sdoc", "~> 1.0.0", group: :doc
 
 group :development, :test do
-  gem "govuk-lint", "4.3.0"
+  gem "rubocop-govuk"
   gem "pry"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,11 +138,6 @@ GEM
     gherkin (5.1.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    govuk-lint (4.3.0)
-      rubocop (~> 0.76)
-      rubocop-rails (~> 2)
-      rubocop-rspec (~> 1.28)
-      scss_lint
     govuk_admin_template (6.7.0)
       bootstrap-sass (= 3.4.1)
       jquery-rails (~> 4.3.1)
@@ -267,8 +262,8 @@ GEM
     omniauth-oauth2 (1.3.1)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
-    parallel (1.18.0)
-    parser (2.6.5.0)
+    parallel (1.19.1)
+    parser (2.7.0.3)
       ast (~> 2.4.0)
     plek (3.0.0)
     pry (0.12.2)
@@ -315,9 +310,6 @@ GEM
     rainbow (3.0.0)
     raindrops (0.19.1)
     rake (13.0.1)
-    rb-fsevent (0.10.3)
-    rb-inotify (0.10.0)
-      ffi (~> 1.0)
     rdoc (6.0.2)
     redis (4.1.3)
     redis-namespace (1.7.0)
@@ -333,26 +325,25 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rubocop (0.76.0)
+    rubocop (0.77.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.6)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
-    rubocop-rails (2.3.2)
+    rubocop-govuk (2.0.0)
+      rubocop (= 0.77)
+      rubocop-rails (~> 2)
+      rubocop-rspec (~> 1.28)
+    rubocop-rails (2.4.2)
       rack (>= 1.1)
       rubocop (>= 0.72.0)
-    rubocop-rspec (1.36.0)
+    rubocop-rspec (1.38.1)
       rubocop (>= 0.68.1)
     ruby-progressbar (1.10.1)
     rubyzip (2.0.0)
     safe_yaml (1.0.5)
-    sass (3.7.4)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.0.1)
@@ -364,8 +355,6 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    scss_lint (0.59.0)
-      sass (~> 3.5, >= 3.5.5)
     sdoc (1.0.0)
       rdoc (>= 5.0)
     selenium-webdriver (3.142.6)
@@ -415,7 +404,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.6)
-    unicode-display_width (1.6.0)
+    unicode-display_width (1.6.1)
     unicorn (5.5.3)
       kgio (~> 2.6)
       raindrops (~> 0.7)
@@ -450,7 +439,6 @@ DEPENDENCIES
   formtastic-bootstrap
   gds-api-adapters (~> 63.5.1)
   gds-sso (~> 14.2.0)
-  govuk-lint (= 4.3.0)
   govuk_admin_template (= 6.7.0)
   govuk_app_config (~> 2.0)
   govuk_sidekiq (~> 3.0.5)
@@ -468,6 +456,7 @@ DEPENDENCIES
   rails (= 5.2.4.1)
   rails-controller-testing
   responders (~> 3.0)
+  rubocop-govuk
   sass-rails (~> 6.0)
   sdoc (~> 1.0.0)
   shoulda-context
@@ -479,4 +468,4 @@ DEPENDENCIES
   webmock (~> 3.8.2)
 
 BUNDLED WITH
-   1.16.2
+   1.17.2

--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,5 @@ if Rails.env.development? || Rails.env.test?
   require 'ci/reporter/rake/minitest'
 end
 
-task default: [:lint]
 Rails.application.load_tasks
 task test: :check_for_bad_time_handling

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -13,7 +13,7 @@ Rails.application.configure do
   config.consider_all_requests_local = true
 
   # Enable/disable caching. By default caching is disabled.
-  if Rails.root.join("tmp", "caching-dev.txt").exist?
+  if Rails.root.join("tmp/caching-dev.txt").exist?
     config.action_controller.perform_caching = true
 
     config.cache_store = :memory_store

--- a/lib/tasks/check_for_bad_time_handling.rake
+++ b/lib/tasks/check_for_bad_time_handling.rake
@@ -1,5 +1,5 @@
 task :check_for_bad_time_handling do
-  directories = Dir.glob(Rails.root.join("**", "*.rb"))
+  directories = Dir.glob(Rails.root.join("**/*.rb"))
   matching_files = directories.select do |filename|
     match = false
     File.open(filename) do |file|

--- a/lib/tasks/cucumber.rake
+++ b/lib/tasks/cucumber.rake
@@ -7,10 +7,12 @@
 
 unless ARGV.any? { |a| a =~ /^gems/ } # Don't load anything when running the gems:* tasks
 
+  # rubocop:disable Rails/FilePath
   vendored_cucumber_bin = Dir[
     Rails.root.join("vendor", "{gems,plugins}", "cucumber*", "bin", "cucumber")
   ].first
   $LOAD_PATH.unshift(File.dirname(vendored_cucumber_bin) + "/../lib") unless vendored_cucumber_bin.nil?
+  # rubocop:enable Rails/FilePath
 
   begin
     require "cucumber/rake/task"

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,4 +1,0 @@
-desc "Run govuk-lint with similar params to CI"
-task "lint" do
-  sh "bundle exec govuk-lint-ruby --diff --format clang app test lib config"
-end

--- a/lib/tasks/queue.rake
+++ b/lib/tasks/queue.rake
@@ -1,7 +1,0 @@
-# FIXME: remove this once we've transitioned to starting sidekiq from the Procfile
-namespace :jobs do
-  task :work do
-    base_path = File.expand_path("../..", __dir__)
-    exec("bundle exec sidekiq -C #{base_path}/config/sidekiq.yml")
-  end
-end

--- a/test/functional/admin/data_sets_controller_test.rb
+++ b/test/functional/admin/data_sets_controller_test.rb
@@ -18,7 +18,7 @@ class Admin::DataSetsControllerTest < ActionController::TestCase
 
     should "successfully import a CSV file" do
       as_logged_in_user do
-        csv_file = fixture_file_upload(Rails.root.join("test", "fixtures", "good_csv.csv"), "text/csv")
+        csv_file = fixture_file_upload(Rails.root.join("test/fixtures/good_csv.csv"), "text/csv")
         post :create, params: { service_id: @service.id, data_set: { data_file: csv_file } }
         assert_response :redirect
 
@@ -46,7 +46,7 @@ class Admin::DataSetsControllerTest < ActionController::TestCase
       DataSet.any_instance.stubs(:data_file=).raises(InvalidCharacterEncodingError)
 
       as_logged_in_user do
-        csv_file = fixture_file_upload(Rails.root.join("test", "fixtures", "good_csv.csv"), "text/csv")
+        csv_file = fixture_file_upload(Rails.root.join("test/fixtures/good_csv.csv"), "text/csv")
         post :create, params: { service_id: @service.id, data_set: { data_file: csv_file } }
         assert_response :redirect
         assert_equal "Could not process CSV file because of the file encoding. Please check the format.", flash[:danger]

--- a/test/unit/file_verifier_test.rb
+++ b/test/unit/file_verifier_test.rb
@@ -3,27 +3,27 @@ require "imminence/file_verifier"
 
 class FileVerifierTest < ActiveSupport::TestCase
   test "it can be handed a file object" do
-    f = File.open(Rails.root.join("features", "support", "data", "register-offices.csv"))
+    f = File.open(Rails.root.join("features/support/data/register-offices.csv"))
     assert_equal "text/plain", Imminence::FileVerifier.new(f).mime_type
   end
 
   test "it can be handed a path" do
-    f = Rails.root.join("features", "support", "data", "register-offices.csv")
+    f = Rails.root.join("features/support/data/register-offices.csv")
     assert_equal "text/plain", Imminence::FileVerifier.new(f).mime_type
   end
 
   test "it correctly identifies a PNG masquerading as a CSV" do
-    f = Rails.root.join("features", "support", "data", "rails.csv")
+    f = Rails.root.join("features/support/data/rails.csv")
     assert_equal "image/png", Imminence::FileVerifier.new(f).mime_type
   end
 
   test "it can provide just the main type of a file" do
-    f = Rails.root.join("features", "support", "data", "rails.csv")
+    f = Rails.root.join("features/support/data/rails.csv")
     assert_equal "image", Imminence::FileVerifier.new(f).type
   end
 
   test "it can provide just the sub-type of a file" do
-    f = Rails.root.join("features", "support", "data", "rails.csv")
+    f = Rails.root.join("features/support/data/rails.csv")
     assert_equal "png", Imminence::FileVerifier.new(f).sub_type
   end
 end


### PR DESCRIPTION
- I'm doing this as part of the GOV.UK Developer Tooling group: https://trello.com/c/pR7GEFfU/128-make-all-current-govuk-repos-use-rubocop-govuk-instead-of-govuk-lint.
- The commit messages have more info.