### PR TITLE
Lint as part of the default rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,8 +2,16 @@
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
 require File.expand_path("config/application", __dir__)
-if Rails.env.development? || Rails.env.test?
-  require "ci/reporter/rake/minitest"
-end
 
 Rails.application.load_tasks
+
+begin
+  require "ci/reporter/rake/minitest"
+  require "rubocop/rake_task"
+  RuboCop::RakeTask.new
+rescue LoadError
+  # Tasks aren't available in all environments
+end
+
+Rake::Task[:default].clear if Rake::Task.task_defined?(:default)
+task default: %i[rubocop cucumber test]


### PR DESCRIPTION
Trello: https://trello.com/c/5Gob6WUL/147-for-everyone-ensure-that-rubocop-runs-as-part-of-bundle-exec-rake-as-one-of-the-default-tasks

We had expected that all apps were linting with the default rake task
and removed the linting step from the Jenkins library [1]. However it
seems this app was missed.

[1]: https://github.com/alphagov/govuk-jenkinslib/pull/74