### PR TITLE
Services that use local authorities are slow

### DIFF
--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -58,6 +58,7 @@ class Place
 
   index({ location: "2d", service_slug: 1, data_set_version: 1 }, background: true)
   index(service_slug: 1, data_set_version: 1)
+  index(snac: 1, data_set_version: 1)
 
   # Index to speed up the `needs_geocoding` and `with_geocoding_errors` scopes
   index(


### PR DESCRIPTION
Services like /register-offices and /heath-protection-team use the snac of a local authority to limit the results.

These services are running a bit slow at the moment, and I've noticed that there is no index on the snac field. Let's see if this makes any difference.

I'm also considering whether we should invert the data_set_version sort, as I think this will do them in ascending order, which is possibly not best.

I'll try that subsequently, but it's good to keep changes small.