### PR TITLE
Use compound index for snac codes

### DIFF
--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -56,9 +56,8 @@ class Place
   validate :has_both_lat_lng_overrides
   validates_with CannotEditPlaceDetailsUnlessNewestInactiveDataset, on: :update
 
-  index({ location: "2d", service_slug: 1, data_set_version: 1 }, background: true)
+  index({ location: "2d", snac: 1, service_slug: 1, data_set_version: 1 }, background: true)
   index(service_slug: 1, data_set_version: 1)
-  index(snac: 1, data_set_version: 1)
 
   # Index to speed up the `needs_geocoding` and `with_geocoding_errors` scopes
   index(


### PR DESCRIPTION
We should include the snac field in the index for searching over locations rather than adding it separately. It should be fine for queries that don't include the snac field.


> Compound indexes are indexes composed of several different fields. For example, instead of having one index on "Last name" and another on "First name", it is typically most efficient to create an index that includes both "Last name" and "First name" if you query against both of the names. Our compound index can still be used to filter queries that specify the last name only.

https://www.mongodb.com/blog/post/performance-best-practices-indexing