### PR TITLE
Change mongo read strategy

### DIFF
--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -19,7 +19,7 @@ test:
         write:
           w: 1
         read:
-          mode: :primary
+          mode: :nearest
         # In the test environment we lower the retries and retry interval to
         # low amounts for fast failures.
         max_retries: 1
@@ -36,7 +36,7 @@ production:
         write:
           w: 1
         read:
-          mode: :primary
+          mode: :nearest
         retry_interval: 120
   options:
     # This is more consistent with ActiveRecord


### PR DESCRIPTION
Similar to https://github.com/alphagov/content-store/pull/604/commits/26f43ee3fd5997524af1cbc6db191b92638cf763

We should be fine to read from any available node, and communication within an AZ is preferable. At present, the primary gets a bit busy on occasion.