### PR TITLE
Prefer reading from secondary mongos

### DIFF
--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -19,7 +19,7 @@ test:
         write:
           w: 1
         read:
-          mode: :nearest
+          mode: :secondary_preferred
         # In the test environment we lower the retries and retry interval to
         # low amounts for fast failures.
         max_retries: 1
@@ -36,7 +36,7 @@ production:
         write:
           w: 1
         read:
-          mode: :nearest
+          mode: :secondary_preferred
         retry_interval: 120
   options:
     # This is more consistent with ActiveRecord


### PR DESCRIPTION
It doesn't look like using `:nearest` has relieved any traffic from the primary. At present the secondary machines are pretty much idle whereas the primary is busy.

https://docs.mongodb.com/mongoid/current/tutorials/mongoid-configuration/