### PR TITLE
Don't do geo_near for snac-bounded services

### DIFF
--- a/app/models/data_set.rb
+++ b/app/models/data_set.rb
@@ -51,10 +51,18 @@ class DataSet
   #   an array of Place objects
   def places_near(location, distance = nil, limit = nil, snac = nil)
     query = places
-    query = query.where(snac: snac) if snac
-    query = query.limit(limit) if limit
-    query = query.geo_near([location.longitude, location.latitude])
-    query = query.max_distance(distance.in(:degrees)) if distance
+
+    # this is a temporary fix while we address poorly performing geo_near queries
+    if snac
+      query = query.where(snac: snac)
+      # currently the max number of places in a local authority is 70
+      query = query.limit(70)
+      query.order_by(name: 1)
+    else
+      query = query.limit(limit) if limit
+      query = query.geo_near([location.longitude, location.latitude])
+      query = query.max_distance(distance.in(:degrees)) if distance
+    end
     query
   end
 

--- a/test/integration/places_api_test.rb
+++ b/test/integration/places_api_test.rb
@@ -228,14 +228,14 @@ class PlacesAPITest < ActionDispatch::IntegrationTest
           @service.update(local_authority_hierarchy_match_type: Service::LOCAL_AUTHORITY_DISTRICT_MATCH)
         end
 
-        should "return the district places in order of nearness, not the county ones for postcodes in a county+district council hierarchy" do
+        should "return the district places in alphabetical order, not the county ones when in a county+district council hierarchy" do
           stub_mapit_postcode_response_from_fixture("EX39 1QS")
 
           get "/places/#{@service.slug}.json?postcode=EX39+1QS"
           data = JSON.parse(last_response.body)
           assert_equal 2, data.length
-          assert_equal @place2.name, data[0]["name"]
-          assert_equal @place1.name, data[1]["name"]
+          assert_equal @place1.name, data[0]["name"]
+          assert_equal @place2.name, data[1]["name"]
         end
 
         should "return all the places in order of nearness for postcodes not in a county+district council hierarchy" do
@@ -254,14 +254,14 @@ class PlacesAPITest < ActionDispatch::IntegrationTest
           @service.update(local_authority_hierarchy_match_type: Service::LOCAL_AUTHORITY_COUNTY_MATCH)
         end
 
-        should "only return the county results in order of nearness, not the district ones for postcodes in a county+district council hierarchy" do
+        should "only return the county results in alphabetical order, and not the district ones when in a county+district council hierarchy" do
           stub_mapit_postcode_response_from_fixture("EX39 1QS")
 
           get "/places/#{@service.slug}.json?postcode=EX39+1QS"
           data = JSON.parse(last_response.body)
           assert_equal 2, data.length
-          assert_equal @place6.name, data[0]["name"]
-          assert_equal @place5.name, data[1]["name"]
+          assert_equal @place5.name, data[0]["name"]
+          assert_equal @place6.name, data[1]["name"]
         end
 
         should "return all the places in order of nearness for postcodes not in a county+district council hierarchy" do

--- a/test/unit/data_set_test.rb
+++ b/test/unit/data_set_test.rb
@@ -412,7 +412,7 @@ class DataSetTest < ActiveSupport::TestCase
         stub_mapit_has_a_postcode_and_areas("EX39 1LH", [51.0413792674, -4.23640704632], [{ "type" => "DIS", "ons" => "18UK" }])
 
         place_names = @data_set.places_for_postcode("EX39 1LH").map(&:name)
-        assert_equal ["Susie's Tea Rooms", "John's Of Appledore"], place_names
+        assert_equal ["John's Of Appledore", "Susie's Tea Rooms"], place_names
       end
 
       should "return multiple places in order of nearness if there are more than one in the district" do


### PR DESCRIPTION
This change skips the geo_near stage for services that reside within a local authority boundary. (e.g /register-offices, /health-protection-teams)

The query instead just finds all the places that are within the desired council and lists them alphabetically.

The performance of the geo_near queries for these services has been getting steadily worse recently. We're investigating why, and will hopefully fix, but in the short term, we'd rather have a working, but slightly less useful system, than one that breaks occasionally.

This will hopefully be reverted soon.