### PR TITLE
Replace inefficient `empty?` conditionals

### DIFF
--- a/app/models/data_set.rb
+++ b/app/models/data_set.rb
@@ -38,6 +38,10 @@ class DataSet
     Place.where(service_slug: service.slug, data_set_version: version)
   end
 
+  def number_of_places
+    places.count
+  end
+
   ##
   # Find all the places near a given location
   #

--- a/app/views/admin/data_sets/_data_set.html.erb
+++ b/app/views/admin/data_sets/_data_set.html.erb
@@ -15,7 +15,7 @@
       <hr />
       <%= render partial: '/admin/data_sets/export', locals: { service: @service, dataset: data_set } %>
 
-      <% if data_set.places.empty? %>
+      <% if data_set.number_of_places.zero? %>
         <p class="alert alert-warning">No places are associated with this set. The imported data could be in the wrong format.</p>
       <% end %>
     <% elsif data_set.processing_error.present? %>

--- a/app/views/admin/services/_history.html.erb
+++ b/app/views/admin/services/_history.html.erb
@@ -22,7 +22,7 @@
         </h3>
       </header>
       <div class="panel-body">
-        <% if set.places.empty? %>
+        <% if set.number_of_places.zero? %>
           <p class="alert alert-warning">No places are associated with this set. The imported data could be in the wrong format.</p>
         <% end %>
 
@@ -39,9 +39,9 @@
             <dt>Change notes</dt>
             <dd><%= set.change_notes %></dd>
           <% end %>
-          <% unless set.places.empty? %>
+          <% unless set.number_of_places.zero? %>
             <dt>Places</dt>
-            <dd><%= set.places.count %></dd>
+            <dd><%= set.number_of_places %></dd>
           <% end %>
         </dl>
         <% if set.processing_complete? %>


### PR DESCRIPTION
The use of `empty?` in a number of conditional statements causes performance issues (the query takes more than 1s to execute for each dataset, so the page often times out).

Switching to use the count instead, which performs a more efficient database query (less than 0.001s per query). Instead of loading the full results (with `empty?`), we are now just getting a count.

Trello card: https://trello.com/c/I8Jqj5RT