### PR TITLE
Revise tech docs in README to favour GOV.UK Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,27 +16,17 @@ There is a simple JSON API for integrating the data with other applications.
 
 ## Technical documentation
 
-Imminence is a Ruby on Rails application backed by a MongoDB database.
+This is a Ruby on Rails app, and should follow [our Rails app conventions](https://docs.publishing.service.gov.uk/manual/conventions-for-rails-applications.html).
 
-### Running the application
+You can use the [GOV.UK Docker environment](https://github.com/alphagov/govuk-docker) to run the application and its tests with all the necessary dependencies. Follow [the usage instructions](https://github.com/alphagov/govuk-docker#usage) to get started.
 
-From within the app root directory:
-
-`./startup.sh`
-
-Note that you will have to have GOV.UK Mapit running locally.
-
-In the GOV.UK DEV VM from the 'development' directory:
-
-`bowl imminence`
-
-Note that the app uses a local version of [GOV.UK Mapit](https://github.com/alphagov/mapit), therefore a valid dataset will have to be loaded for Mapit, otherwise postcode lookups will not succeed. This is part of the standard GOV.UK data replication steps.
+**Use GOV.UK Docker to run any commands that follow.**
 
 ### Running the test suite
 
-`bundle exec rake`
-
-`bundle exec govuk-lint-ruby app test lib`
+```sh
+bundle exec rake
+```
 
 ## Licence
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,10 @@
 # Imminence
 
-Imminence manages sets of (somewhat) structured data for use elsewhere on GOV.UK.
-It's primarily used for geographical data such as lists of registry offices, test
-centres, and the like.
+Imminence manages sets of (somewhat) structured data for use elsewhere on GOV.UK. It's primarily used for geographical data such as lists of registry offices, test centres, and the like.
 
-The data is structured as a set of Services which represent a distinct type of
-location. A Service can then have many Data Sets which are in turn collections of
-Places. Only one Data Set will be "active" at any given time.
+The data is structured as a set of Services which represent a distinct type of location. A Service can then have many Data Sets which are in turn collections of Places. Only one Data Set will be "active" at any given time.
 
-Each data set is uploaded as a CSV file. A cron job takes care of geocoding the
-places within it. It can then be manually inspected or exported as CSV, JSON or KML
-so it can be tested using a variety of other tools.
+Each data set is uploaded as a CSV file. A cron job takes care of geocoding the places within it. It can then be manually inspected or exported as CSV, JSON or KML so it can be tested using a variety of other tools.
 
 There is a simple JSON API for integrating the data with other applications.
 

--- a/README.md
+++ b/README.md
@@ -24,10 +24,6 @@ There is a simple JSON API for integrating the data with other applications.
 
 Imminence is a Ruby on Rails application backed by a MongoDB database.
 
-### Dependencies
-
-- [alphagov/mapit](https://github.com/alphagov/mapit) - provides postcode lookups
-
 ### Running the application
 
 From within the app root directory:

--- a/startup.sh
+++ b/startup.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-bundle install
-bundle exec rails s -p 3002


### PR DESCRIPTION
This makes several changes to refactor and revise the README to better match our other repos. The end result follows the pattern established in https://github.com/alphagov/content-publisher/pull/2257. See the commit messages for more details.

[Trello Card](https://trello.com/c/Psf7EzPB/204-move-away-from-startupsh)