### PR TITLE
Swap `places.any?` for a more efficient option

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -72,12 +72,12 @@ class Service
   end
 
   def schedule_archive_places
-    obsolete_data_sets.each { |ds| ds.archive! if ds.places.any? }
+    obsolete_data_sets.each { |ds| ds.archive! if ds.places.count.positive? }
     ArchivePlacesWorker.perform_async(id.to_s)
   end
 
   def archive_places
-    obsolete_data_sets.each { |ds| ds.archive_places if ds.places.any? }
+    obsolete_data_sets.each { |ds| ds.archive_places if ds.places.count.positive? }
   end
 
   # returns all data sets up to but not including the data set before the active set


### PR DESCRIPTION
Using `any?` on a results set loads those objects in order to count them. Using `count` on the results is much faster as it's a native database query.

Similar to https://github.com/alphagov/imminence/pull/624