### PR TITLE
Revert "Don't do geo_near for snac-bounded services"

### DIFF
--- a/app/models/data_set.rb
+++ b/app/models/data_set.rb
@@ -55,18 +55,10 @@ class DataSet
   #   an array of Place objects
   def places_near(location, distance = nil, limit = nil, snac = nil)
     query = places
-
-    # this is a temporary fix while we address poorly performing geo_near queries
-    if snac
-      query = query.where(snac: snac)
-      # currently the max number of places in a local authority is 70
-      query = query.limit(70)
-      query.order_by(name: 1)
-    else
-      query = query.limit(limit) if limit
-      query = query.geo_near([location.longitude, location.latitude])
-      query = query.max_distance(distance.in(:degrees)) if distance
-    end
+    query = query.where(snac: snac) if snac
+    query = query.limit(limit) if limit
+    query = query.geo_near([location.longitude, location.latitude])
+    query = query.max_distance(distance.in(:degrees)) if distance
     query
   end
 

--- a/test/integration/places_api_test.rb
+++ b/test/integration/places_api_test.rb
@@ -228,14 +228,14 @@ class PlacesAPITest < ActionDispatch::IntegrationTest
           @service.update(local_authority_hierarchy_match_type: Service::LOCAL_AUTHORITY_DISTRICT_MATCH)
         end
 
-        should "return the district places in alphabetical order, not the county ones when in a county+district council hierarchy" do
+        should "return the district places in order of nearness, not the county ones for postcodes in a county+district council hierarchy" do
           stub_mapit_postcode_response_from_fixture("EX39 1QS")
 
           get "/places/#{@service.slug}.json?postcode=EX39+1QS"
           data = JSON.parse(last_response.body)
           assert_equal 2, data.length
-          assert_equal @place1.name, data[0]["name"]
-          assert_equal @place2.name, data[1]["name"]
+          assert_equal @place2.name, data[0]["name"]
+          assert_equal @place1.name, data[1]["name"]
         end
 
         should "return all the places in order of nearness for postcodes not in a county+district council hierarchy" do
@@ -254,14 +254,14 @@ class PlacesAPITest < ActionDispatch::IntegrationTest
           @service.update(local_authority_hierarchy_match_type: Service::LOCAL_AUTHORITY_COUNTY_MATCH)
         end
 
-        should "only return the county results in alphabetical order, and not the district ones when in a county+district council hierarchy" do
+        should "only return the county results in order of nearness, not the district ones for postcodes in a county+district council hierarchy" do
           stub_mapit_postcode_response_from_fixture("EX39 1QS")
 
           get "/places/#{@service.slug}.json?postcode=EX39+1QS"
           data = JSON.parse(last_response.body)
           assert_equal 2, data.length
-          assert_equal @place5.name, data[0]["name"]
-          assert_equal @place6.name, data[1]["name"]
+          assert_equal @place6.name, data[0]["name"]
+          assert_equal @place5.name, data[1]["name"]
         end
 
         should "return all the places in order of nearness for postcodes not in a county+district council hierarchy" do

--- a/test/unit/data_set_test.rb
+++ b/test/unit/data_set_test.rb
@@ -412,7 +412,7 @@ class DataSetTest < ActiveSupport::TestCase
         stub_mapit_has_a_postcode_and_areas("EX39 1LH", [51.0413792674, -4.23640704632], [{ "type" => "DIS", "ons" => "18UK" }])
 
         place_names = @data_set.places_for_postcode("EX39 1LH").map(&:name)
-        assert_equal ["John's Of Appledore", "Susie's Tea Rooms"], place_names
+        assert_equal ["Susie's Tea Rooms", "John's Of Appledore"], place_names
       end
 
       should "return multiple places in order of nearness if there are more than one in the district" do


### PR DESCRIPTION
This reverts commit 965af26af4aeda755203c2e8bf9584160ed9a18d.

This will now return the 10 nearest locations in order of closeness again. At present we just return an alphabetical list of all places in the local authority

We've recently cleaned the data, so we think this might now be performant again.