### PR TITLE
Initialize govuk_admin_template via environment variables

### DIFF
--- a/config/initializers/govuk_admin_template.rb
+++ b/config/initializers/govuk_admin_template.rb
@@ -1,0 +1,2 @@
+GovukAdminTemplate.environment_label = ENV.fetch("GOVUK_ENVIRONMENT_NAME", "development").titleize
+GovukAdminTemplate.environment_style = ENV["GOVUK_ENVIRONMENT_NAME"] == "production" ? "production" : "preview"


### PR DESCRIPTION
This PR sets `environment_label` and `environment_style` for the deprecated `govuk_admin_template` gem via environment variables, through a new initializer file. Currently whenever an app is deployed through Jenkins, [Jenkins writes an initializer file to `config/initializers` containing the values for these two properties based on conditional](https://github.com/alphagov/govuk-app-deployment/blob/c52a9c767dff658a912aa62cea5adde6d28ea94d/recipes/govuk_admin_template.rb) over the `ORGANISATION` variable that is set in Jenkins and passed through to `govuk-app-deployment`.

Such practice is against the 12 factor app methodology and has recently been discovered as an issue for Replatforming, where we are not using Jenkins (nor `govuk-app-deployment`) and so not writing this extra initializer file. Instead, this commit introduces a new `GOVUK_ENVIRONMENT_NAME` variable which will be used as the canonical source of truth to determine an app's environment and can be used to remove any other environment variables which we're abusing to serve this purpose (`ERRBIT_ENVIRONMENT_NAME` for instance).

Trello: https://trello.com/c/0Z2F9lKU

[A separate commit introduces this variable to `govuk-puppet`](alphagov/govuk-puppet@5fc81d2).