### PR TITLE
Add new Pact test for the areas/postcode endpoint

### DIFF
--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -49,18 +49,20 @@ Pact.provider_states_for "GDS API Adapters" do
 
   provider_state "a place exists with a postcode and areas" do
     set_up do
+      postcode = "WC2B 6SE"
+
       service = create(:service, slug: "local-authority")
-      create(:place, service_slug: service.slug, postcode: "WC2B 6SE")
+      create(:place, service_slug: service.slug, postcode: postcode)
 
       areas = [
-        { "name" => "Westminster City Council", "type" => "LBO" },
-        { "name" => "London", "type" => "EUR" },
+        { "name" => "Westminster City Council", "country_name" => "England", "type" => "LBO", "gss" => "E12000008" },
+        { "name" => "London", "country_name" => "England", "type" => "EUR", "gss" => "E12000009" },
       ]
 
       response = {
         "wgs84_lat" => 51.516,
         "wgs84_lon" => -0.121,
-        "postcode" => "WC2B 6SE",
+        "postcode" => postcode,
       }
 
       area_response = Hash[areas.map.with_index do |area, i|
@@ -77,12 +79,8 @@ Pact.provider_states_for "GDS API Adapters" do
          }]
       end]
 
-      postcode = "WC2B 6SE"
-
-      stub_request(:get, "#{MAPIT_ENDPOINT}/postcode/#{postcode.tr(' ', '+')}.json")
+      stub_request(:get, "#{MAPIT_ENDPOINT}/postcode/#{postcode.sub(' ', '+')}.json")
         .to_return(body: response.merge("areas" => area_response).to_json, status: 200)
-      stub_request(:get, "#{MAPIT_ENDPOINT}/postcode/partial/#{postcode.split(' ').first}.json")
-        .to_return(body: response.to_json, status: 200)
     end
   end
 end

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -14,6 +14,8 @@ end
 
 WebMock.allow_net_connect!
 
+MAPIT_ENDPOINT = Plek.current.find("mapit")
+
 def url_encode(str)
   ERB::Util.url_encode(str)
 end
@@ -42,6 +44,45 @@ Pact.provider_states_for "GDS API Adapters" do
     set_up do
       service = create(:service, slug: "number-plate-supplier")
       create(:place, service_slug: service.slug, latitude: 50.742754933617285, longitude: -1.9552618901330387)
+    end
+  end
+
+  provider_state "a place exists with a postcode and areas" do
+    set_up do
+      service = create(:service, slug: "local-authority")
+      create(:place, service_slug: service.slug, postcode: "WC2B 6SE")
+
+      areas = [
+        { "name" => "Westminster City Council", "type" => "LBO" },
+        { "name" => "London", "type" => "EUR" },
+      ]
+
+      response = {
+        "wgs84_lat" => 51.516,
+        "wgs84_lon" => -0.121,
+        "postcode" => "WC2B 6SE",
+      }
+
+      area_response = Hash[areas.map.with_index do |area, i|
+        [i,
+         {
+           "codes" => {
+             "ons" => area["ons"],
+             "gss" => area["gss"],
+             "govuk_slug" => area["govuk_slug"],
+           },
+           "name" => area["name"],
+           "type" => area["type"],
+           "country_name" => area["country_name"],
+         }]
+      end]
+
+      postcode = "WC2B 6SE"
+
+      stub_request(:get, "#{MAPIT_ENDPOINT}/postcode/#{postcode.tr(' ', '+')}.json")
+        .to_return(body: response.merge("areas" => area_response).to_json, status: 200)
+      stub_request(:get, "#{MAPIT_ENDPOINT}/postcode/partial/#{postcode.split(' ').first}.json")
+        .to_return(body: response.to_json, status: 200)
     end
   end
 end


### PR DESCRIPTION
An additional pact test for imminence, so we can test an endpoint that doesn't just return a `place` (as most of them do).

Trello: https://trello.com/c/clyNd0c5/2521-3-finish-adding-contract-tests-for-imminence