### PR TITLE
Handle UndefinedConversionError

### DIFF
--- a/app/controllers/admin/data_sets_controller.rb
+++ b/app/controllers/admin/data_sets_controller.rb
@@ -8,6 +8,7 @@ class Admin::DataSetsController < InheritedResources::Base
   belongs_to :service
   rescue_from CSV::MalformedCSVError, with: :bad_csv
   rescue_from InvalidCharacterEncodingError, with: :bad_encoding
+  rescue_from Encoding::UndefinedConversionError, with: :bad_encoding
 
   def create
     prohibit_non_csv_uploads


### PR DESCRIPTION
This crops up when the CsvData model attempts to convert windows-1252 to utf-8 and fails (i.e., input is neither of those encodings).

https://trello.com/c/jPdEOLPI/1158-unable-to-import-dataset-in-imminence
