### PR TITLE
Fix config.hosts

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -59,7 +59,6 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
-  config.hosts += [
-    "imminence.dev.gov.uk",
-  ]
+  # Allow requests for all domains e.g. <app>.dev.gov.uk
+  config.hosts.clear
 end


### PR DESCRIPTION
We were sometimes seeing Pact test failures around requests being
made to example.org. This is because we had a hard-coded list of
allowed hosts, which only included imminence.dev.gov.uk.
Our standard approach is to clear the hosts config in development,
e.g. https://github.com/alphagov/content-publisher/blob/3b1f2794ad42f3acadb04c3b8351336a6bdc031d/config/environments/development.rb#L17-L18