### PR TITLE
Fixup CSV processing

### DIFF
--- a/app/models/data_set.rb
+++ b/app/models/data_set.rb
@@ -159,12 +159,15 @@ class DataSet
       Place.create!(places_data)
       reset_csv_data
       save!
+    else
+      self.processing_error = "CSV file empty. Try again or contact support."
     end
   rescue CSV::MalformedCSVError
     self.processing_error = "Could not process CSV file. Please check the format."
     reset_csv_data
     save!
   rescue Mongoid::Errors::MongoidError
+    self.processing_error = "Database error occurred. Please try re-importing."
     reset_csv_data
     save!
   end

--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -34,7 +34,7 @@ production:
       uri: <%= ENV['MONGODB_URI'] %>
       options:
         write:
-          w: 1
+          w: 3 # prevents race conditions
         read:
           mode: :secondary_preferred
         retry_interval: 120

--- a/features/support/data/register-offices-with-missing-snac-codes.csv
+++ b/features/support/data/register-offices-with-missing-snac-codes.csv
@@ -2,4 +2,3 @@ name,address1,address2,town,postcode,access_notes,general_notes,url,lat,lng,phon
 Town Hall,Cauldwell Street,Bedford,,MK42 9AP,,,http://www.bedford.gov.uk/advice_and_benefits/registration_service.aspx,52.1327584352089,-0.4702813074674147,,,,00KB
 County Hall,Walton Street,Aylesbury,,HP20 1XF,,,http://www.buckscc.gov.uk/registration/index.stm,51.81525988351161,-0.8119554673823927,,,,
 Shire Hall,Castle Hill,Cambridge,,CB3 0AP,,,http://www.cambridgeshire.gov.uk/community/bmd/,52.2128132777458,0.11402791296760088,,,,
-


### PR DESCRIPTION
This fixes two problems:

* CSV processing could fail silently
* CSV processing could fail due to a race condition, where the Sidekiq processing job ran before the data to be processed is available in every Mongodb node

Zendesk ticket: https://govuk.zendesk.com/agent/tickets/4693254
Trello: https://trello.com/c/RPSwI8yz/1212-bug-preventing-imminence-csv-uploads

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
