### PR TITLE
Allow a more realistic interpretation of csv mime types

### DIFF
--- a/app/controllers/admin/data_sets_controller.rb
+++ b/app/controllers/admin/data_sets_controller.rb
@@ -49,7 +49,7 @@ protected
     if params[:data_set] && params[:data_set][:data_file]
       file = get_file_from_param(params[:data_set][:data_file])
       fv = Imminence::FileVerifier.new(file)
-      unless fv.type == "text"
+      unless fv.csv?
         message = "Rejecting file with content type: #{fv.mime_type}"
         Rails.logger.info(message)
         raise CSV::MalformedCSVError.new(message, 0)

--- a/app/controllers/admin/services_controller.rb
+++ b/app/controllers/admin/services_controller.rb
@@ -23,7 +23,7 @@ protected
     if params[:service][:data_file]
       file = get_file_from_param(params[:service][:data_file])
       fv = Imminence::FileVerifier.new(file)
-      unless fv.type == "text"
+      unless fv.csv?
         message = "Rejecting file with content type: #{fv.mime_type}"
         Rails.logger.info(message)
         params[:service].delete(:data_file)

--- a/lib/imminence/file_verifier.rb
+++ b/lib/imminence/file_verifier.rb
@@ -2,12 +2,22 @@ module Imminence
   class FileVerifier
     attr_accessor :filename
 
+    CSV_TYPES = [
+      "text/csv",         # Ideal, per RFC4180
+      "text/plain",       # Current per remote system
+      "application/csv",  # Current per docker
+    ].freeze
+
     def initialize(file)
       @filename = if file.respond_to?(:path)
                     file.path
                   else
                     file.to_s
                   end
+    end
+
+    def csv?
+      CSV_TYPES.include?(mime_type)
     end
 
     def type

--- a/test/unit/file_verifier_test.rb
+++ b/test/unit/file_verifier_test.rb
@@ -4,16 +4,17 @@ require "imminence/file_verifier"
 class FileVerifierTest < ActiveSupport::TestCase
   test "it can be handed a file object" do
     f = File.open(Rails.root.join("features/support/data/register-offices.csv"))
-    assert_equal "text/plain", Imminence::FileVerifier.new(f).mime_type
+    assert_equal true, Imminence::FileVerifier.new(f).csv?
   end
 
   test "it can be handed a path" do
     f = Rails.root.join("features/support/data/register-offices.csv")
-    assert_equal "text/plain", Imminence::FileVerifier.new(f).mime_type
+    assert_equal true, Imminence::FileVerifier.new(f).csv?
   end
 
   test "it correctly identifies a PNG masquerading as a CSV" do
     f = Rails.root.join("features/support/data/rails.csv")
+    assert_equal false, Imminence::FileVerifier.new(f).csv?
     assert_equal "image/png", Imminence::FileVerifier.new(f).mime_type
   end
 


### PR DESCRIPTION
The method we use to detect csv files is pretty shaky - it returns different values in docker, on the desktop, and remotely. Unfortunately, there's not really any improvement on it - csv files are essentially detected by "this isn't any other type of file, so it must be text I guess". By opening up the mime types considered as CSV, we allow  the test suite to run on govuk-docker again. It's arguably a bit of test-induced damage, but I couldn't find a better solution that wasn't heavy duty.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
