### PR TITLE
Relax CSV file generation and simplify error messages

### DIFF
--- a/app/controllers/admin/data_sets_controller.rb
+++ b/app/controllers/admin/data_sets_controller.rb
@@ -36,7 +36,7 @@ class Admin::DataSetsController < InheritedResources::Base
 protected
 
   def bad_encoding
-    flash[:danger] = "Could not process CSV file because of the file encoding. Please check the format."
+    flash[:danger] = "Could not process CSV file. Please check the format."
     redirect_back(fallback_location: admin_service_url(service))
   end
 

--- a/app/controllers/admin/services_controller.rb
+++ b/app/controllers/admin/services_controller.rb
@@ -12,7 +12,7 @@ class Admin::ServicesController < InheritedResources::Base
     @service = Service.new(service_params)
     render action: "new"
   rescue InvalidCharacterEncodingError
-    flash.now[:danger] = "Could not process CSV file because of the file encoding. Please check the format."
+    flash.now[:danger] = "Could not process CSV file. Please check the format."
     @service = Service.new(service_params)
     render action: "new"
   end

--- a/lib/imminence/file_verifier.rb
+++ b/lib/imminence/file_verifier.rb
@@ -17,6 +17,8 @@ module Imminence
     end
 
     def csv?
+      return true if File.extname(@filename) == ".csv"
+
       CSV_TYPES.include?(mime_type)
     end
 

--- a/test/functional/admin/data_sets_controller_test.rb
+++ b/test/functional/admin/data_sets_controller_test.rb
@@ -49,7 +49,7 @@ class Admin::DataSetsControllerTest < ActionController::TestCase
         csv_file = fixture_file_upload(Rails.root.join("test/fixtures/good_csv.csv"), "text/csv")
         post :create, params: { service_id: @service.id, data_set: { data_file: csv_file } }
         assert_response :redirect
-        assert_equal "Could not process CSV file because of the file encoding. Please check the format.", flash[:danger]
+        assert_equal "Could not process CSV file. Please check the format.", flash[:danger]
         # There is always an initial data set
         assert_equal 1, Service.first.data_sets.count
         assert_equal 0, Place.count

--- a/test/unit/file_verifier_test.rb
+++ b/test/unit/file_verifier_test.rb
@@ -12,12 +12,6 @@ class FileVerifierTest < ActiveSupport::TestCase
     assert_equal true, Imminence::FileVerifier.new(f).csv?
   end
 
-  test "it correctly identifies a PNG masquerading as a CSV" do
-    f = Rails.root.join("features/support/data/rails.csv")
-    assert_equal false, Imminence::FileVerifier.new(f).csv?
-    assert_equal "image/png", Imminence::FileVerifier.new(f).mime_type
-  end
-
   test "it can provide just the main type of a file" do
     f = Rails.root.join("features/support/data/rails.csv")
     assert_equal "image", Imminence::FileVerifier.new(f).type


### PR DESCRIPTION
Relaxes further the CSV format checks on import. Not only are there multiple different mimetypes for CSV files, but there are other problems with detection. For instance, if a line starts with a capital C then a space (as in "C S Moorland garages", the system will detect it as a fortran file and reject it). This has caused actual problems in import and resulted in 2nd line toil.

Since we're allowing only logged-in users to import and not members of the public, it seems safe to relax the import - we don't need to catch .pngs disguised as .csv files any more, we can just assume that anything labelled .csv _is_ a CSV file, and pass it to the CSV load process (which will still fail it if it isn't valid).  

It's also not clear the two different errors ("Could not process CSV file because of the file encoding. Please check the format" and "Could not process CSV file. Please check the format" provided any useful difference for the end user, so have collapsed them into one).

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
