### PR TITLE
Add task to prune obsolete datasets

### DIFF
--- a/lib/tasks/prune_archived_datasets.rake
+++ b/lib/tasks/prune_archived_datasets.rake
@@ -1,0 +1,43 @@
+namespace :prune_archived_datasets do
+  desc "Delete all archived DataSets apart from the most recent 3, and attached PlaceArchives"
+  task go: [:environment] do
+    prune_archived_datasets(dry_run: false)
+  end
+
+  task dry_run: [:environment] do
+    prune_archived_datasets(dry_run: true)
+  end
+end
+
+def prune_archived_datasets(dry_run: true)
+  if dry_run
+    puts("DRY RUN: NO DELETIONS WILL TAKE PLACE")
+  else
+    puts("LIVE RUN: RECORDS WILL BE DELETED")
+  end
+
+  Service.each do |service|
+    archived_data_sets = service
+      .data_sets
+      .where(state: "archived")
+      .asc(:version)
+
+    archived_data_sets_count = archived_data_sets.count
+
+    next unless archived_data_sets_count > 3
+
+    deletable_data_set_versions = archived_data_sets
+      .first(archived_data_sets_count - 3)
+      .pluck(:version)
+
+    puts("#{service.name}: #{deletable_data_set_versions.count} archived datasets to delete")
+
+    deletable_place_archives = PlaceArchive.where(service_slug: service.slug)
+                                           .in(data_set_version: deletable_data_set_versions)
+
+    puts("#{service.name}: #{deletable_place_archives.count} place archives to delete")
+
+    archived_data_sets.in(version: deletable_data_set_versions).delete_all unless dry_run
+    deletable_place_archives.delete_all unless dry_run
+  end
+end


### PR DESCRIPTION
Adds a task that reduces the size of the Mongo db by deleting all archived datasets apart from the most recent 3 (this leaves the last 5 versions, since the current active and previous one are unarchived by default), and deletes all PlaceArchive records attached to those deleted datasets.

Use:
rake prune_archived_datasets:dry_run (to do a dry_run, ie no actual deletions but does the output)
rake prune_archived_datasets:go (do the actual deletions)

- [x] [Dry run in integration](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/304914/console)
- [x] [Real run in integration](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/304917/console)

https://trello.com/c/QSIlx7rz/1419-reduce-placesarchive-in-imminence

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
