### PR TITLE
Update database cleaner to specific Mongoid version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem "state_machines-mongoid"
 gem "uglifier"
 
 group :development, :test do
-  gem "database_cleaner", "1.8.5"
+  gem "database_cleaner-mongoid"
   gem "pact", require: false
   gem "pact_broker-client"
   gem "pry-byebug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,7 +142,10 @@ GEM
     cucumber-wire (6.2.1)
       cucumber-core (~> 10.1, >= 10.1.0)
       cucumber-cucumber-expressions (~> 14.0, >= 14.0.0)
-    database_cleaner (1.8.5)
+    database_cleaner-core (2.0.1)
+    database_cleaner-mongoid (2.0.1)
+      database_cleaner-core (~> 2.0.0)
+      mongoid
     diff-lcs (1.5.0)
     dig_rb (1.0.1)
     digest (3.1.0)
@@ -564,7 +567,7 @@ DEPENDENCIES
   bootstrap-kaminari-views
   ci_reporter_minitest
   cucumber-rails
-  database_cleaner (= 1.8.5)
+  database_cleaner-mongoid
   factory_bot_rails
   gds-api-adapters
   gds-sso

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -35,7 +35,7 @@ ActionController::Base.allow_rescue = false
 # Remove/comment out the lines below if your app doesn't have a database.
 # For some databases (like MongoDB and CouchDB) you may need to use :truncation instead.
 begin
-  DatabaseCleaner[:mongoid].strategy = :truncation
+  DatabaseCleaner[:mongoid].strategy = :deletion
 rescue NameError
   raise "You need to add database_cleaner to your Gemfile (in the :test group) if you wish to use it."
 end

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -1,7 +1,7 @@
 require "pact/provider/rspec"
 require "webmock/rspec"
 require "factory_bot_rails"
-require "database_cleaner"
+require "database_cleaner-mongoid"
 
 require ::File.expand_path("../../config/environment", __dir__)
 
@@ -36,7 +36,7 @@ end
 
 Pact.provider_states_for "GDS API Adapters" do
   set_up do
-    DatabaseCleaner.clean_with :truncation
+    DatabaseCleaner.clean_with :deletion
     GDS::SSO.test_user = create(:user, permissions: %w[signin])
   end
 

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -1,7 +1,7 @@
 require_relative "test_helper"
 require "capybara/rails"
 
-DatabaseCleaner.strategy = :truncation
+DatabaseCleaner.strategy = :deletion
 
 class ActionDispatch::IntegrationTest
   include Capybara::DSL

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,7 @@
 require "simplecov"
 SimpleCov.start "rails"
 
-require "database_cleaner"
+require "database_cleaner-mongoid"
 
 ENV["RAILS_ENV"] ||= "test"
 require File.expand_path("../config/environment", __dir__)


### PR DESCRIPTION
Allows update to Version 2.0.1
Change strategy (DBC mongoid only supports deletion)

https://trello.com/c/0DmAxikJ/1285-update-database-cleaner-in-imminence

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
