### PR TITLE
Add deletion policy for old archives

### DIFF
--- a/app/controllers/admin/data_sets_controller.rb
+++ b/app/controllers/admin/data_sets_controller.rb
@@ -26,7 +26,11 @@ class Admin::DataSetsController < InheritedResources::Base
   def activate
     if resource.activate
       flash[:success] = "Data Set #{resource.version} successfully activated"
-      resource.service.schedule_archive_places if resource.latest_data_set?
+
+      if resource.latest_data_set?
+        resource.service.schedule_archive_places
+        resource.service.schedule_delete_historic_records
+      end
     else
       flash[:danger] = "Couldn't activate data set"
     end

--- a/app/models/data_set.rb
+++ b/app/models/data_set.rb
@@ -197,6 +197,11 @@ class DataSet
     set(archiving_error: "Failed to archive place information: '#{e.message}'")
   end
 
+  def delete_records
+    PlaceArchive.where(service_slug: service.slug, data_set_version: version).delete_all
+    delete
+  end
+
   def new_action(user, type, comment)
     action = Action.new(requester_id: user.id, request_type: type, comment: comment)
     actions << action

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -78,7 +78,15 @@ class Service
   end
 
   def archive_places
-    obsolete_data_sets.each { |ds| ds.archive_places if ds.places.count.positive? }
+    obsolete_data_sets.each do |ds|
+      next if ds.archived?
+
+      if ds.places.count.positive?
+        ds.archive_places
+      else
+        ds.delete
+      end
+    end
   end
 
   def schedule_delete_historic_records

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -5,6 +5,7 @@ class Service
   LOCAL_AUTHORITY_DISTRICT_MATCH = "district".freeze
   LOCAL_AUTHORITY_COUNTY_MATCH = "county".freeze
   LOCAL_AUTHORITY_HIERARCHY_MATCH_TYPES = [LOCAL_AUTHORITY_DISTRICT_MATCH, LOCAL_AUTHORITY_COUNTY_MATCH].freeze
+  MAX_ARCHIVES_TO_STORE = 3
 
   field :name,                    type: String
   field :slug,                    type: String
@@ -78,6 +79,20 @@ class Service
 
   def archive_places
     obsolete_data_sets.each { |ds| ds.archive_places if ds.places.count.positive? }
+  end
+
+  def delete_historic_records
+    archived_data_sets = data_sets.where(state: "archived").asc(:version)
+
+    archived_data_sets_count = archived_data_sets.count
+
+    return if archived_data_sets_count <= MAX_ARCHIVES_TO_STORE
+
+    deletable_data_sets = archived_data_sets.first(
+      archived_data_sets_count - MAX_ARCHIVES_TO_STORE,
+    )
+
+    deletable_data_sets.each(&:delete_records)
   end
 
   # returns all data sets up to but not including the data set before the active set

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -81,6 +81,10 @@ class Service
     obsolete_data_sets.each { |ds| ds.archive_places if ds.places.count.positive? }
   end
 
+  def schedule_delete_historic_records
+    DeleteHistoricRecordsWorker.perform_async(id)
+  end
+
   def delete_historic_records
     archived_data_sets = data_sets.where(state: "archived").asc(:version)
 

--- a/app/workers/delete_historic_records_worker.rb
+++ b/app/workers/delete_historic_records_worker.rb
@@ -1,0 +1,8 @@
+class DeleteHistoricRecordsWorker
+  include Sidekiq::Worker
+
+  def perform(service_id)
+    service = Service.find(service_id)
+    service.delete_historic_records
+  end
+end

--- a/test/factories/factories.rb
+++ b/test/factories/factories.rb
@@ -1,4 +1,11 @@
 FactoryBot.define do
+  factory :user do
+    sequence(:uid) { |n| "uid-#{n}" }
+    sequence(:name) { |n| "Joe Bloggs #{n}" }
+    sequence(:email) { |n| "joe#{n}@bloggs.com" }
+    permissions { %w[signin] }
+  end
+
   factory :service do
     name { "Important Government Service" }
     sequence(:slug) { |n| "important-government-service-#{n}" }

--- a/test/factories/factories.rb
+++ b/test/factories/factories.rb
@@ -27,4 +27,43 @@ FactoryBot.define do
     phone { "01234 567890" }
     location { Point.new(latitude: latitude, longitude: longitude) }
   end
+
+  factory :place_archive do
+    transient do
+      latitude { 53.105491 }
+      longitude { -2.017493 }
+    end
+
+    service_slug { (Service.first || create(:service)).slug }
+    data_set_version { Service.where(slug: service_slug).first.active_data_set_version }
+    name { "CosaNostra Pizza #3569" }
+    sequence(:address1) { |n| "#{n} Vista Road" }
+    town { "Los Angeles" }
+    postcode { "WC2B 6NH" }
+    phone { "01234 567890" }
+    location { Point.new(latitude: latitude, longitude: longitude) }
+  end
+
+  factory :data_set do
+    service { create(:service) }
+
+    after(:create) do |data_set, _evaluator|
+      create_list(:place,
+                  3,
+                  data_set_version: data_set.version,
+                  service_slug: data_set.service.slug)
+    end
+  end
+
+  factory :archived_data_set, class: DataSet do
+    service { create(:service) }
+    state { "archived" }
+
+    after(:create) do |data_set, _evaluator|
+      create_list(:place_archive,
+                  3,
+                  data_set_version: data_set.version,
+                  service_slug: data_set.service.slug)
+    end
+  end
 end

--- a/test/factories/user_factories.rb
+++ b/test/factories/user_factories.rb
@@ -1,8 +1,0 @@
-FactoryBot.define do
-  factory :user do
-    sequence(:uid) { |n| "uid-#{n}" }
-    sequence(:name) { |n| "Joe Bloggs #{n}" }
-    sequence(:email) { |n| "joe#{n}@bloggs.com" }
-    permissions { %w[signin] }
-  end
-end

--- a/test/functional/admin/data_sets_controller_test.rb
+++ b/test/functional/admin/data_sets_controller_test.rb
@@ -9,6 +9,7 @@ class Admin::DataSetsControllerTest < ActionController::TestCase
     @service = FactoryBot.create(:service)
     stub_mapit_does_not_have_a_postcode("IG6 3HJ")
     Sidekiq::Testing.inline!
+    Sidekiq::Worker.clear_all
   end
 
   context "POST create" do

--- a/test/functional/admin/data_sets_controller_test.rb
+++ b/test/functional/admin/data_sets_controller_test.rb
@@ -111,6 +111,16 @@ class Admin::DataSetsControllerTest < ActionController::TestCase
           assert_equal 1, ArchivePlacesWorker.jobs.count
         end
       end
+
+      should "create a background job for deleting historic records" do
+        as_logged_in_user do
+          post :activate, params: { service_id: @service.id, id: @service.latest_data_set.id }
+          job = DeleteHistoricRecordsWorker.jobs.last
+          service_id_to_process = job["args"].first
+          assert_equal @service, Service.find(service_id_to_process)
+          assert_equal 1, DeleteHistoricRecordsWorker.jobs.count
+        end
+      end
     end
 
     context "when duplicating a data set" do

--- a/test/unit/service_test.rb
+++ b/test/unit/service_test.rb
@@ -180,11 +180,17 @@ class ServiceTest < ActiveSupport::TestCase
       assert @service.data_sets.first.archiving?
     end
 
-    should "not archive obsolete data_sets without places" do
+    should "delete archive obsolete data_sets without places" do
       ds = @service.data_sets.first
       ds.places.delete_all
       @service.archive_places
-      assert ds.unarchived?
+      assert_not ds.persisted?
+    end
+
+    should "doesn't action already archived data_sets" do
+      archived_ds = FactoryBot.create(:archived_data_set, service: @service)
+      @service.archive_places
+      assert archived_ds.persisted?
     end
   end
 

--- a/test/workers/delete_historic_records_worker_test.rb
+++ b/test/workers/delete_historic_records_worker_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+
+class DeleteHistoricRecordsWorkerTest < ActiveSupport::TestCase
+  context "running the worker" do
+    setup do
+      Sidekiq::Testing.inline!
+
+      @service = FactoryBot.create(:service)
+      @service.data_sets.delete_all
+      FactoryBot.create_list(:archived_data_set, 6, service: @service)
+      FactoryBot.create(:data_set, state: :unarchived, service: @service)
+    end
+
+    should "delete historic records" do
+      assert_equal 7, @service.data_sets.count
+      assert_equal 18, PlaceArchive.where(service_slug: @service.slug).count
+
+      DeleteHistoricRecordsWorker.new.perform(@service.id)
+
+      assert_equal 9, PlaceArchive.where(service_slug: @service.slug).count
+      assert_equal [4, 5, 6, 7], @service.reload.data_sets.pluck(:version).sort
+      @service.reload.data_sets.in(version: [4, 5, 6]).each do |data_set|
+        assert_equal 3, PlaceArchive.where(service_slug: @service.slug,
+                                           data_set_version: data_set.version).count
+      end
+    end
+  end
+end


### PR DESCRIPTION
Old archives built up in the database causing huge bloat and degraded performance in the app. We ran a [one off rake task](https://github.com/alphagov/imminence/pull/770) to clear the bulk of them, but needed a deletion policy to prevent the same thing happening in the future.

We now only keep 3 archived data sets and associated archive places.

Trello: https://trello.com/c/l599ORxF/1418-change-archiving-approach-for-placesarchive-in-imminence

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
