### PR TITLE
remove obsolete .bundle/config

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,2 +1,0 @@
----
-BUNDLE_DISABLE_EXEC_LOAD: "true"


### PR DESCRIPTION
Looks like this might not be necessary any more? 

Originally brought in here: https://github.com/alphagov/imminence/pull/142 - we use cucumber all over the place, though, and no other repos have this config, so it feels like it's no longer an issue.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
