### PR TITLE
Remove internal mongoid ID from being returned in API

### DIFF
--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -181,6 +181,10 @@ class Place
     override_lat.present? && override_lng.present?
   end
 
+  def as_json(_options)
+    super(except: [:_id])
+  end
+
 private
 
   def clear_location


### PR DESCRIPTION
This field is internal to Mongoid so shouldn't be returned anyway, and won't be in future. The consumer (frontend) doesn't use it, so safe to remove.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
