### PR TITLE
Dockerfile fixes and cleanup.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,14 @@
 .github
 Dockerfile
 Jenkinsfile
+Procfile
 README.md
+coverage
 docs
+features
+log
+script
+spec
+test
 tmp
+vendor

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,26 @@
-ARG base_image=ghcr.io/alphagov/govuk-ruby-base:3.0.4
-ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:3.0.4
+ARG ruby_version=3.0.4
+ARG base_image=ghcr.io/alphagov/govuk-ruby-base:$ruby_version
+ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:$ruby_version
+
 
 FROM $builder_image AS builder
 
-WORKDIR /app
-
-COPY Gemfile* .ruby-version /app/
-
+WORKDIR $APP_HOME
+COPY Gemfile* .ruby-version ./
 RUN bundle install
+COPY . .
+RUN bootsnap precompile --gemfile .
+RUN rails assets:precompile && rm -fr log
 
-COPY . /app
-
-RUN bundle exec rails assets:precompile && \
-    rm -fr /app/log
 
 FROM $base_image
 
 ENV GOVUK_APP_NAME=imminence
 
-WORKDIR /app
-
-COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
-COPY --from=builder /app /app/
+WORKDIR $APP_HOME
+COPY --from=builder $BUNDLE_PATH $BUNDLE_PATH
+COPY --from=builder $BOOTSNAP_CACHE_DIR $BOOTSNAP_CACHE_DIR
+COPY --from=builder $APP_HOME .
 
 USER app
-
-CMD ["bundle", "exec", "puma"]
+CMD ["puma"]

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gem "rails", "7.0.4"
 
+gem "bootsnap", require: false
 gem "bootstrap-kaminari-views"
 gem "gds-api-adapters"
 gem "gds-sso"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,8 @@ GEM
     autoprefixer-rails (10.4.7.0)
       execjs (~> 2)
     awesome_print (1.9.2)
+    bootsnap (1.15.0)
+      msgpack (~> 1.2)
     bootstrap-kaminari-views (0.0.5)
       kaminari (>= 0.13)
       rails (>= 3.1)
@@ -277,6 +279,7 @@ GEM
       activemodel (>= 5.1, < 7.1, != 7.0.0)
       mongo (>= 2.10.5, < 3.0.0)
       ruby2_keywords (~> 0.0.5)
+    msgpack (1.6.0)
     multi_test (1.1.0)
     multi_xml (0.6.0)
     net-imap (0.3.1)
@@ -560,6 +563,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  bootsnap
   bootstrap-kaminari-views
   ci_reporter_minitest
   cucumber-rails
@@ -598,4 +602,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.1.4
+   2.3.6

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,5 +31,9 @@ module Imminence
       g.template_engine :erb # this could be :haml or whatever
       g.test_framework :test_unit, fixture: false # this could be :rpsec or whatever
     end
+
+    # Set asset path to be application specific so that we can put all GOV.UK
+    # assets into an S3 bucket and distinguish app by path.
+    config.assets.prefix = "/assets/imminence"
   end
 end

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,3 +1,4 @@
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
 require "bundler/setup" # Set up gems listed in the Gemfile.
+require "bootsnap/setup"


### PR DESCRIPTION
- Fix Rails assets deployment to S3 by including the app name in the Rails assets path.
- Parameterise the Ruby version.
- Enable [bootsnap](https://github.com/Shopify/bootsnap#bootsnap-).
- Remove some hard-coded paths.
- Clean up `.dockerignore`.
- Make better use of `WORKDIR`.
- Remove the now-redundant `bundle exec` from the default command.

Tested: builds and comes up healthy on the integration Kubernetes cluster.