### PR TITLE
Run Pact test as CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,12 @@ jobs:
     name: Lint Ruby
     uses: alphagov/govuk-infrastructure/.github/workflows/rubocop.yml@main
 
+  pact-tests:
+    name: Run Pact tests
+    uses: ./.github/workflows/pact-verify.yml
+    with:
+      commitish: ${{ github.ref }}
+
   test-ruby:
     name: Test Ruby
     runs-on: ubuntu-latest

--- a/.github/workflows/pact-verify.yml
+++ b/.github/workflows/pact-verify.yml
@@ -7,19 +7,16 @@
 name: Run Pact tests
 
 on:
-  pull_request:
-  push:
   workflow_call:
     inputs:
-      # what branch or Git SHA to clone this app with, only applies when
-      # called as a workflow, so current commit applies to push/pull requests
       commitish:
         required: false
         type: string
         default: main
       pact_consumer_version:
-        required: true
+        required: false
         type: string
+        default: branch-main
 
 jobs:
   pact_verify:
@@ -33,14 +30,14 @@ jobs:
           POSTGRES_HOST_AUTH_METHOD: trust
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     env:
-      PACT_CONSUMER_VERSION: ${{ inputs.pact_consumer_version || 'branch-main' }}
+      PACT_CONSUMER_VERSION: ${{ inputs.pact_consumer_version }}
       TEST_DATABASE_URL: postgis://postgres@localhost/test-db
       RAILS_ENV: test
     steps:
       - uses: actions/checkout@v3
         with:
           repository: alphagov/imminence
-          ref: ${{ inputs.commitish || github.sha }}
+          ref: ${{ inputs.commitish }}
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true


### PR DESCRIPTION
This runs Pact tests as a job with in CI, instead of triggering a seperate workflow. This consolidates and makes the CI triggers consistent.
