### PR TITLE
Allow imminence to return split postcode addresses and accept local authority slugs

### DIFF
--- a/app/models/ambiguous_postcode_error.rb
+++ b/app/models/ambiguous_postcode_error.rb
@@ -1,0 +1,8 @@
+class AmbiguousPostcodeError < StandardError
+  attr_reader :addresses
+
+  def initialize(addresses)
+    super()
+    @addresses = addresses
+  end
+end

--- a/test/functional/places_controller_test.rb
+++ b/test/functional/places_controller_test.rb
@@ -48,7 +48,11 @@ class PlacesControllerTest < ActionController::TestCase
     as_logged_in_user do
       get :show, params: { id: @service.slug }, format: :json
       assert_response :success
-      assert_equal 4, JSON.parse(response.body).size
+      data = JSON.parse(response.body)
+
+      assert_equal "ok", data["status"]
+      assert_equal "places", data["contents"]
+      assert_equal 4, data["places"].size
     end
   end
 
@@ -58,7 +62,7 @@ class PlacesControllerTest < ActionController::TestCase
       assert_response :success
       json_data = JSON.parse(response.body)
 
-      place = json_data.find { |p| p["source_address"] == "Aviation House" }
+      place = json_data["places"].find { |p| p["source_address"] == "Aviation House" }
       assert_equal "WC2B 6SE", place["postcode"]
       location_hash = {
         "latitude" => 51.516960431,
@@ -74,7 +78,7 @@ class PlacesControllerTest < ActionController::TestCase
       assert_response :success
       json_data = JSON.parse(response.body)
 
-      place = json_data.find { |p| p["source_address"] == "Nowhere" }
+      place = json_data["places"].find { |p| p["source_address"] == "Nowhere" }
       assert_nil place["location"]
     end
   end


### PR DESCRIPTION
Imminence has to be able to detect a split postcode in a local_authority type search (they're not so important in nearest searches), and return a list of addresses with local authority slugs for the frontend to render into a chooser. Then it also has to be able to take the local authority slug as an optional extra for a postcode search and disambiguate depending on that slug.

Note about return values - we're using the existing "validPostcodeNoLocation" for the situation where a local_authority_slug doesn't exist, because it falls naturally out of the code as it exists and it's correct that the postcode is valid, but the postcode doesn't return any locations if paired with a missing LA. That said, it's perhaps not ideal but should be addressed as part of the more general cleanup of Imminence error handling in this card: https://trello.com/c/KNAZN3Fm/1706-ps-4-frontend-places-stop-silencing-errors

https://trello.com/c/C4nLJyVO/1770-add-split-postcode-support-for-places-in-frontend

- [x] Return addresses if split postcode detected and search is local_authority
- [x] Tests for address return
- [x] Accept local_authority_slug as a disambiguator to postcode search
- [x] Test for disambiguation slug
- [x] Test that invalid disambiguation slug is handled correctly

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
