### PR TITLE
added prometheus initializer

### DIFF
--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -1,0 +1,2 @@
+require "govuk_app_config/govuk_prometheus_exporter"
+GovukPrometheusExporter.configure


### PR DESCRIPTION
This change is only enabled in the EKS environment.
It is required so that the prometheus monitoring module that's already installed as part of govuk_app_config is initialized when the container is running.