### PR TITLE
Strip id from places when archiving to prevent collisions

### DIFF
--- a/app/models/data_set.rb
+++ b/app/models/data_set.rb
@@ -231,10 +231,10 @@ class DataSet < ApplicationRecord
 
   def archive_places
     places.each do |place|
-      PlaceArchive.create!(place.attributes)
+      PlaceArchive.create!(place.attributes.except("id"))
     end
     places.delete_all
-    archived
+    archived!
   rescue StandardError => e
     update!(archiving_error: "Failed to archive place information: '#{e.message}'")
   end

--- a/test/unit/data_set_test.rb
+++ b/test/unit/data_set_test.rb
@@ -69,6 +69,16 @@ class DataSetTest < ActiveSupport::TestCase
       assert_equal 5, PlaceArchive.all.count
     end
 
+    should "not copy ids when archiving, so that we don't get clashes" do
+      ds = @service.data_sets.first
+      FactoryBot.create(:place_archive, id: ds.places.first.id)
+      ActiveRecord::Base.connection.reset_pk_sequence!("place_archives")
+      ds.archive!
+      ds.archive_places
+      assert ds.archived?
+      assert_nil ds.archiving_error
+    end
+
     should "remove its place information" do
       ds = @service.data_sets.first
       ds.archive_places


### PR DESCRIPTION
When activating a new dataset, we're automatically trying to archive the old ones. Unfortunately, this fails (the dataset gets activated, but it looks like a failure to the administrator), because we have a bunch of datasets in an archiving state that have failed to archive their places.

It looks like this is because when we create the new PlaceArchive records, we're copying across the id field, which isn't guaranteed to be free in PlaceArchive, of course. I'm not sure why it's allowing us to do this, since id should be a protected attribute, but here we are. This was fine in Mongo days, but causes a unique key violation in PG, so we strip the id from the Place attributes before creating a PlaceArchive record for them.

I've added a test for this, where I reset the key sequence for the PlaceArchive table after creating the first record (the one that would cause an ID collision if the fix weren't in place). This is because creating the first PlaceArchive with a specified ID causes the table to get confused in the test. Not a thing that should happen in real life.

https://trello.com/c/1TJiKCco/1944-ps25-archive-failures-on-imminence

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
