### PR TITLE
Add Per-Department Permissions

### DIFF
--- a/app/controllers/admin/admin_controller_mixin.rb
+++ b/app/controllers/admin/admin_controller_mixin.rb
@@ -4,6 +4,8 @@ module Admin::AdminControllerMixin
 
     base.before_action :authenticate_user!
     base.send :defaults, route_prefix: "admin"
+    base.helper_method :gds_editor?
+    base.helper_method :org_name_for_current_user
   end
 
   def get_file_from_param(param)
@@ -12,5 +14,23 @@ module Admin::AdminControllerMixin
     else
       param
     end
+  end
+
+  def gds_editor?
+    current_user.permissions.include?("GDS Editor")
+  end
+
+  def service_owner?(service)
+    service.organisation_slugs.include?(current_user.organisation_slug)
+  end
+
+  def permission_for_service?(service)
+    gds_editor? || service_owner?(service)
+  end
+
+  def org_name_for_current_user
+    GdsApi.organisations.organisation(current_user.organisation_slug).to_hash["title"]
+  rescue GdsApi::HTTPUnavailable
+    current_user.organisation_slug
   end
 end

--- a/app/controllers/admin/data_sets_controller.rb
+++ b/app/controllers/admin/data_sets_controller.rb
@@ -10,6 +10,8 @@ class Admin::DataSetsController < InheritedResources::Base
   rescue_from InvalidCharacterEncodingError, with: :bad_encoding
   rescue_from Encoding::UndefinedConversionError, with: :bad_encoding
 
+  before_action :check_permission!
+
   def create
     prohibit_non_csv_uploads
     create! do |_success, failure|
@@ -74,5 +76,11 @@ protected
     # This is ActiveAdmin's accessor for the service object. We are calling it
     # directly rather than using the @ accessor.
     parent
+  end
+
+  def check_permission!
+    return if permission_for_service?(service)
+
+    raise PermissionDeniedException, "Sorry, you do not have permission to edit datasets for this service."
   end
 end

--- a/app/controllers/admin/places_controller.rb
+++ b/app/controllers/admin/places_controller.rb
@@ -3,6 +3,7 @@ class Admin::PlacesController < InheritedResources::Base
   actions :all, except: %i[show index]
   belongs_to :service
   belongs_to :data_set
+  before_action :check_permission!
 
   def new
     @place = parent.places.build
@@ -66,5 +67,11 @@ protected
         :access_notes,
         :general_notes,
       )
+  end
+
+  def check_permission!
+    return if permission_for_service?(service)
+
+    raise PermissionDeniedException, "Sorry, you do not have permission to edit places for this service."
   end
 end

--- a/app/views/admin/services/_form_fields.html.erb
+++ b/app/views/admin/services/_form_fields.html.erb
@@ -17,6 +17,18 @@
     </span>
   </div>
 
+  <% if current_user.permissions.include?("GDS Editor") %>
+    <div class="form-group">
+      <span class="form-label">
+        <%= f.label :organisation_slugs %>
+      </span>
+      <span class="form-wrapper">
+        <%= f.text_field :organisation_slugs, class: "input-md-6 form-control" %>
+      </span>
+      <p class="hint-text">For multiple owning organisations, list slugs separated by spaces</p>
+    </div>
+  <% end %>
+
   <% if f.object.new_record? %>
     <div class="form-group">
       <span class="form-label">

--- a/app/views/admin/services/index.html.erb
+++ b/app/views/admin/services/index.html.erb
@@ -1,11 +1,17 @@
-<% content_for :page_title, "All services" %>
+<% title = gds_editor? ? "All services" : "All services for #{org_name_for_current_user}" %>
+<% content_for :page_title, title %>
+
 <div class="page-header">
   <h1>
-    All services
+    <%= title %>
   </h1>
 </div>
 
-<%= link_to new_admin_service_path, :class => "btn btn-default" do %>Add new service<% end %>
+<% if gds_editor? %>
+  <%= link_to new_admin_service_path, class: "btn btn-default" do %>
+    <span class="glyphicon glyphicon-plus"></span> Add new service
+  <% end %>
+<% end %>
 
 <table class="add-top-margin table table-striped table-bordered" summary="Full list of available services" data-module="filterable-table">
   <thead>

--- a/db/migrate/20240306155313_modify_services_add_organisation_slug.rb
+++ b/db/migrate/20240306155313_modify_services_add_organisation_slug.rb
@@ -1,0 +1,5 @@
+class ModifyServicesAddOrganisationSlug < ActiveRecord::Migration[7.0]
+  def change
+    add_column :services, :organisation_slugs, :string, array: true, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_09_093208) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_06_155313) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -108,6 +108,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_09_093208) do
     t.string "local_authority_hierarchy_match_type", default: "district"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "organisation_slugs", default: [], array: true
     t.index ["slug"], name: "index_services_on_slug", unique: true
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,4 +6,4 @@
 #   cities = City.create([{ :name => 'Chicago' }, { :name => 'Copenhagen' }])
 #   Mayor.create(:name => 'Daley', :city => cities.first)
 
-User.find_or_create_by!(name: "publisher")
+User.find_or_create_by!(name: "publisher", organisation_slug: "test-org")

--- a/docs/adr/adr-001-department-permissions.md
+++ b/docs/adr/adr-001-department-permissions.md
@@ -1,0 +1,41 @@
+# Decision Record: Department Permissions
+
+## Introduction
+
+In March 2024 a proposal was put to SteerCo to allow departments direct access
+to Imminence to maintain their own datasets. Although all data in Imminence is
+publicly available, we agreed with John-Paul Dickie (and previously with Alex
+Pardoe) that it would make sense to restrict dataset updating to the owning
+department to avoid the risk of datasets being accidentally overwritten by
+non-owner departments.
+
+## Requirements
+
+Each service would need to be owned by one or more departments. Only editors
+with Imminence access permission in Signon should be allowed to view and edit
+those services, with the usual caveat that selected GOV.UK staff should be
+allowed to access all services for troubleshooting and incident response.
+
+We looked at the way this was handled in Whitehall and other publishing apps,
+where Signon provides the current user's organisational slug and access can
+be limited based on that. A "GDS Editor" special permission is also typical
+of these apps.
+
+## Resulting changes
+
+- Add an "organisational_slugs" field to each service, to be filled in by
+  us for existing services before departments are given access. This will
+  be a simple string field, with comma separation for multiple owners.
+- Add a "GDS Editor" permission. Anyone with this permission can see and
+  edit all services/datasets/places. Anyone without this permission can
+  only access services whose organisational_slugs field contains the same
+  slug as reported for them by Signon.
+- When new services are made they will automatically be assigned an
+  organisational_slug identical to the current user's, unless the user
+  has the GDS Editor permission, in which case they will be able to edit
+  the slug directly.
+
+We will not at the moment add in an organisational drop-down, so any GDS
+Editor making changes to the organisation slug will need to know the
+correct one, but it is assumed that people with this permission will know
+how to find that out.

--- a/features/data_sets.feature
+++ b/features/data_sets.feature
@@ -3,7 +3,7 @@ Feature: Managing data sets
   I want to manage sets of data
 
   Background:
-    Given I am an admin
+    Given I am an editor
 
   Scenario: Adding another data set to a service
     Given I have previously created the "Register Offices" service

--- a/features/permissions.feature
+++ b/features/permissions.feature
@@ -1,0 +1,30 @@
+Feature: Service Permissions
+  In order to ensure services can only be accessed by relevant editors
+  I want to see only my department's services
+
+  Scenario: Viewing My Department's Services
+    Given I am an editor
+    Given test-department exists
+    Given a test-department editor has previously created the "Register Offices" service
+
+    When I go to the service list page
+
+    Then I should be able to see the Register Offices service
+
+  Scenario: Viewing Other Department's Services
+    Given I am an editor
+    Given test-department exists
+    Given an other-department editor has previously created the "Register Offices" service
+
+    When I go to the service list page
+
+    Then I should not be able to see the Register Offices service
+
+
+  Scenario: Viewing Services
+    Given I am a GDS editor
+    Given an other-department editor has previously created the "Register Offices" service
+
+    When I go to the service list page
+
+    Then I should be able to see the Register Offices service

--- a/features/services.feature
+++ b/features/services.feature
@@ -3,13 +3,14 @@ Feature: Managing services
   I want to manage services
 
   Background:
-    Given I am an admin
+    Given I am an editor
 
   Scenario: Creating a new service
     When I go to the new service page
       And I fill out the form with the following attributes to create a service:
         | name                                 | Register Offices         |
         | slug                                 | all-new-register-offices |
+        | organisation_slugs                   | test-department          |
         | source_of_data                       | Testing source of data   |
         | location_match_type                  | Local authority          |
         | local_authority_hierarchy_match_type | County                   |

--- a/features/step_definitions/service_steps.rb
+++ b/features/step_definitions/service_steps.rb
@@ -4,6 +4,12 @@ Given(/^I have previously created the "(.*?)" service$/) do |name|
   @service = create_service(params)
 end
 
+Given(/^(?:a|an) (.*?) editor has previously created the "(.*?)" service$/) do |organisation_slug, name|
+  params = { name:, slug: name.parameterize, organisation_slugs: [organisation_slug], csv_path: csv_path_for_data(name) }
+
+  @service = create_service(params)
+end
+
 Given(/^I have previously created a service with the following attributes:$/) do |table|
   params = table.rows_hash.symbolize_keys!
   raise ArgumentError, "name cannot be nil" if params[:name].nil?
@@ -30,6 +36,19 @@ end
 
 When(/^I visit the history tab$/) do
   click_link "Version history"
+end
+
+When("I go to the service list page") do
+  GdsApiHelper.new.stub_search_finds_no_govuk_pages
+  visit root_path
+end
+
+Then("I should be able to see the Register Offices service") do
+  expect(page).to have_content("Register Offices")
+end
+
+Then("I should not be able to see the Register Offices service") do
+  expect(page).to_not have_content("Register Offices")
 end
 
 When(/^I fill in the form to create the "(.*?)" service with a bad CSV$/) do |name|

--- a/features/step_definitions/session_steps.rb
+++ b/features/step_definitions/session_steps.rb
@@ -1,4 +1,13 @@
-Given(/^I am (?:a|an) (admin)$/) do |_role|
-  user = FactoryBot.create(:user, name: "user")
+Given(/^I am (?:a|an) (editor)$/) do |_role|
+  user = FactoryBot.create(:user, name: "user", organisation_slug: "test-department", permissions: %w[Editor])
   login_as user
+end
+
+Given(/^I am (?:a|an) (GDS editor)$/) do |_role|
+  user = FactoryBot.create(:user, name: "user", organisation_slug: "government-digital-service", permissions: ["GDS Editor"])
+  login_as user
+end
+
+Given(/^test-department exists$/) do
+  GdsApiHelper.new.stub_organisations_test_department
 end

--- a/features/support/gds_api_helper.rb
+++ b/features/support/gds_api_helper.rb
@@ -1,0 +1,14 @@
+require "gds_api/test_helpers/organisations"
+
+class GdsApiHelper
+  include WebMock::API
+  include GdsApi::TestHelpers::Organisations
+
+  def stub_organisations_test_department
+    stub_organisations_api_has_organisations_with_bodies([{ "title" => "Department of Testing", "details" => { "slug" => "test-department" } }])
+  end
+
+  def stub_search_finds_no_govuk_pages
+    stub_request(:get, "http://search-api.dev.gov.uk/search.json?count=200&fields=title,link&filter_format=place").to_return(status: 200, body: { results: [] }.to_json, headers: {})
+  end
+end

--- a/features/support/service_helper.rb
+++ b/features/support/service_helper.rb
@@ -47,6 +47,7 @@ module ServiceHelper
       location_match_type: location_match_type(params[:location_match_type]),
       local_authority_hierarchy_match_type: local_authority_hierarchy_match_type(params[:local_authority_hierarchy_match_type]),
       data_file: File.open(params[:csv_path]),
+      organisation_slugs: params[:organisation_slugs].split(",") || %w[test-department],
     )
     s.save!
     run_all_delayed_jobs

--- a/features/support/service_helper.rb
+++ b/features/support/service_helper.rb
@@ -47,7 +47,7 @@ module ServiceHelper
       location_match_type: location_match_type(params[:location_match_type]),
       local_authority_hierarchy_match_type: local_authority_hierarchy_match_type(params[:local_authority_hierarchy_match_type]),
       data_file: File.open(params[:csv_path]),
-      organisation_slugs: params[:organisation_slugs].split(",") || %w[test-department],
+      organisation_slugs: params[:organisation_slugs] ? params[:organisation_slugs].split(",") : %w[test-department],
     )
     s.save!
     run_all_delayed_jobs

--- a/test/factories/factories.rb
+++ b/test/factories/factories.rb
@@ -3,13 +3,20 @@ FactoryBot.define do
     sequence(:uid) { |n| "uid-#{n}" }
     sequence(:name) { |n| "Joe Bloggs #{n}" }
     sequence(:email) { |n| "joe#{n}@bloggs.com" }
-    permissions { %w[signin] }
+    organisation_slug { "test-department" }
+    permissions { %w[signin Editor] }
+  end
+
+  factory :gds_editor_user, class: User, parent: :user do
+    organisation_slug { "government-digital-service" }
+    permissions { ["signin", "GDS Editor"] }
   end
 
   factory :service do
     name { "Important Government Service" }
     sequence(:slug) { |n| "important-government-service-#{n}" }
     source_of_data { "Somewhere beyond the sea" }
+    organisation_slugs { %w[test-department] }
   end
 
   factory :place do

--- a/test/functional/admin/places_controller_test.rb
+++ b/test/functional/admin/places_controller_test.rb
@@ -13,7 +13,7 @@ class Admin::PlacesControllerTest < ActionController::TestCase
       end
 
       should "display the new place form" do
-        as_logged_in_user do
+        as_gds_editor do
           get :new, params: { service_id: @service.id, data_set_id: @data_set.id }
 
           assert_response(:success)
@@ -21,8 +21,16 @@ class Admin::PlacesControllerTest < ActionController::TestCase
         end
       end
 
+      should "not display the new place form if user is not in the test department" do
+        as_other_department_user do
+          get :new, params: { service_id: @service.id, data_set_id: @data_set.id }
+
+          assert_response(:forbidden)
+        end
+      end
+
       should "persist a new place correctly" do
-        as_logged_in_user do
+        as_gds_editor do
           place_attributes = {
             name: "Plaice Inc.",
             postcode: "FY4 1AZ",
@@ -46,7 +54,7 @@ class Admin::PlacesControllerTest < ActionController::TestCase
       end
 
       should "not show the new place form" do
-        as_logged_in_user do
+        as_gds_editor do
           get :new, params: { service_id: @service.id, data_set_id: @data_set.id }
 
           assert_redirected_to admin_service_data_set_url(@service, @data_set)
@@ -54,7 +62,7 @@ class Admin::PlacesControllerTest < ActionController::TestCase
       end
 
       should "not persist a new place" do
-        as_logged_in_user do
+        as_gds_editor do
           place_attributes = {
             name: "The Original Plaice Co.",
             postcode: "FY4 1AZ",
@@ -76,7 +84,7 @@ class Admin::PlacesControllerTest < ActionController::TestCase
       end
 
       should "display the edit form" do
-        as_logged_in_user do
+        as_gds_editor do
           get :edit, params: { service_id: @service.id, data_set_id: @data_set.id, id: @place.id }
 
           assert_response(:success)
@@ -88,7 +96,7 @@ class Admin::PlacesControllerTest < ActionController::TestCase
       end
 
       should "persist changes" do
-        as_logged_in_user do
+        as_gds_editor do
           put :update,
               params: { service_id: @service.id,
                         data_set_id: @data_set.id,
@@ -103,7 +111,7 @@ class Admin::PlacesControllerTest < ActionController::TestCase
       end
 
       should "ignore nil or blank overridden latitude and longitude params" do
-        as_logged_in_user do
+        as_gds_editor do
           put :update,
               params: { service_id: @service.id,
                         data_set_id: @data_set.id,
@@ -120,7 +128,7 @@ class Admin::PlacesControllerTest < ActionController::TestCase
       end
 
       should "create a location from overridden latitude and longitude params" do
-        as_logged_in_user do
+        as_gds_editor do
           put :update,
               params: { service_id: @service.id,
                         data_set_id: @data_set.id,
@@ -144,7 +152,7 @@ class Admin::PlacesControllerTest < ActionController::TestCase
       end
 
       should "not allow the place to be edited" do
-        as_logged_in_user do
+        as_gds_editor do
           get :edit, params: { service_id: @service.id, data_set_id: @data_set.id, id: @place.id }
 
           assert_redirected_to admin_service_data_set_url(@service, @data_set)
@@ -152,7 +160,7 @@ class Admin::PlacesControllerTest < ActionController::TestCase
       end
 
       should "not persist changes" do
-        as_logged_in_user do
+        as_gds_editor do
           put :update,
               params: { service_id: @service.id,
                         data_set_id: @data_set.id,
@@ -174,7 +182,7 @@ class Admin::PlacesControllerTest < ActionController::TestCase
       end
 
       should "not allow the place to be edited" do
-        as_logged_in_user do
+        as_gds_editor do
           get :edit, params: { service_id: @service.id, data_set_id: @data_set.id, id: @place.id }
 
           assert_redirected_to admin_service_data_set_url(@service, @data_set)
@@ -182,7 +190,7 @@ class Admin::PlacesControllerTest < ActionController::TestCase
       end
 
       should "not persist changes" do
-        as_logged_in_user do
+        as_gds_editor do
           put :update,
               params: { service_id: @service.id,
                         data_set_id: @data_set.id,

--- a/test/functional/admin/services_controller_test.rb
+++ b/test/functional/admin/services_controller_test.rb
@@ -2,12 +2,13 @@ require "test_helper"
 
 class Admin::ServicesControllerTest < ActionController::TestCase
   test "should create service" do
-    as_logged_in_user do
+    as_gds_editor do
       service_params = {
-        "name" => "Register Offices",
-        "slug" => "register-offices",
-        "location_match_type" => "local_authority",
-        "local_authority_hierarchy_match_type" => "county",
+        name: "Register Offices",
+        slug: "register-offices",
+        organisation_slugs: "government-digital-service test-service",
+        location_match_type: "local_authority",
+        local_authority_hierarchy_match_type: "county",
       }
 
       post :create, params: { service: service_params }
@@ -18,8 +19,39 @@ class Admin::ServicesControllerTest < ActionController::TestCase
       service = Service.last
       assert_equal "Register Offices", service.name
       assert_equal "register-offices", service.slug
+      assert_equal %w[government-digital-service test-service], service.organisation_slugs
       assert_equal "local_authority", service.location_match_type
       assert_equal "county", service.local_authority_hierarchy_match_type
+    end
+  end
+
+  context "with a service created by test-department" do
+    setup do
+      @service = FactoryBot.create(:service)
+    end
+
+    should "not be visible to other-department user" do
+      as_other_department_user do
+        get :show, params: { id: @service.id }
+
+        assert_response :forbidden
+      end
+    end
+
+    should "be visible to test-department user" do
+      as_test_department_user do
+        get :show, params: { id: @service.id }
+
+        assert_response :ok
+      end
+    end
+
+    should "be visible to GDS Editor" do
+      as_gds_editor do
+        get :show, params: { id: @service.id }
+
+        assert_response :ok
+      end
     end
   end
 end

--- a/test/functional/places_controller_test.rb
+++ b/test/functional/places_controller_test.rb
@@ -45,7 +45,7 @@ class PlacesControllerTest < ActionController::TestCase
   end
 
   test "as a logged in user I can access a non-active data set" do
-    as_logged_in_user do
+    as_gds_editor do
       get :show, params: { id: @service.slug }, format: :json
       assert_response :success
       data = JSON.parse(response.body)
@@ -57,7 +57,7 @@ class PlacesControllerTest < ActionController::TestCase
   end
 
   test "can show a JSON representation of places" do
-    as_logged_in_user do
+    as_gds_editor do
       get :show, params: { id: @service.slug }, format: :json
       assert_response :success
       json_data = JSON.parse(response.body)
@@ -73,7 +73,7 @@ class PlacesControllerTest < ActionController::TestCase
   end
 
   test "can show a JSON representation of a place with no coordinates" do
-    as_logged_in_user do
+    as_gds_editor do
       get :show, params: { id: @service.slug }, format: :json
       assert_response :success
       json_data = JSON.parse(response.body)
@@ -84,7 +84,7 @@ class PlacesControllerTest < ActionController::TestCase
   end
 
   test "can show a KML representation of places" do
-    as_logged_in_user do
+    as_gds_editor do
       get :show, params: { id: @service.slug }, format: :kml
       assert_response :success
       kml_data = Hash.from_xml(response.body)

--- a/test/integration/places_api_test.rb
+++ b/test/integration/places_api_test.rb
@@ -82,6 +82,7 @@ class PlacesAPITest < ActionDispatch::IntegrationTest
 
       should "return requested version when logged in" do
         GDS::SSO.test_user = FactoryBot.create(:user)
+        stub_organisations_test_department
         visit "/admin" # necessary to setup the login session
 
         visit "/places/#{@service.slug}.json?version=#{@data_set1.to_param}"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -44,10 +44,22 @@ class ActiveSupport::TestCase
   end
   set_callback :setup, :before, :reset_sidekiq_testing
 
-  def as_logged_in_user(&_block)
+  def as_gds_editor(&block)
+    as_logged_in_user(["GDS Editor"], "government-digital-service", &block)
+  end
+
+  def as_test_department_user(&block)
+    as_logged_in_user([], "test-department", &block)
+  end
+
+  def as_other_department_user(&block)
+    as_logged_in_user([], "other-department", &block)
+  end
+
+  def as_logged_in_user(permissions, organisation_slug, &_block)
     @controller.stubs(:authenticate_user!).returns(true)
     @controller.stubs(:user_signed_in?).returns(true)
-    @controller.stubs(:current_user).returns(User.new)
+    @controller.stubs(:current_user).returns(User.new(permissions:, organisation_slug:))
     yield
     @controller.unstub(:current_user)
     @controller.unstub(:user_signed_in?)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,6 +9,7 @@ require "rails/test_help"
 require "mocha/minitest"
 require "gds_api/test_helpers/json_client_helper"
 require "gds_api/test_helpers/locations_api"
+require "gds_api/test_helpers/organisations"
 require "webmock/minitest"
 require "govuk_sidekiq/testing"
 # Poltergeist requires access to localhost.
@@ -22,6 +23,7 @@ reporter_options = { color: true }
 Minitest::Reporters.use! [Minitest::Reporters::DefaultReporter.new(reporter_options)]
 
 class ActiveSupport::TestCase
+  include GdsApi::TestHelpers::Organisations
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   # fixtures :all
 
@@ -82,5 +84,9 @@ class ActiveSupport::TestCase
   def stub_locations_api_does_not_have_a_postcode(postcode)
     stub_request(:get, "#{GdsApi::TestHelpers::LocationsApi::LOCATIONS_API_ENDPOINT}/v1/locations?postcode=#{postcode}")
       .to_return(body: { "errors" => { "postcode" => ["No results found for given postcode"] } }.to_json, status: 404)
+  end
+
+  def stub_organisations_test_department
+    stub_organisations_api_has_organisations_with_bodies([{ "title" => "Department of Testing", "details" => { "slug" => "test-department" } }])
   end
 end


### PR DESCRIPTION
To allow department dataset maintainers to upload their own data and reduce the workload of junior content designers, who are currently acting as intermediaries for this work on Content 2L. Add a solution based on the signon user's organisation slug, which matches how this is handled in Whitehall.

https://trello.com/c/UHBoqLxy/1893-add-per-department-permissions-to-imminence

- Adds new organisation_slugs column to the Services database
- Enforces that the current user either has the new gds-editor permission, or their organisation slug matches the owner of the service. This is enforced at service, data set and place editing. (There is an existing editor permission, but it isn't really used, and gds-editor is clearer, since that is often used for super-privileges)
- Adds the ability to edit the organisation_slugs in the Service admin page, only if the gds-editor permission exists.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
