### PR TITLE
Update Mocha to handle Minitest name issue

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -782,7 +782,7 @@ DEPENDENCIES
   kaminari
   launchy
   minitest-reporters
-  mocha
+  mocha (= 2.1.0)
   pact
   pact_broker-client
   pg


### PR DESCRIPTION
Mocha 2.0.4 relied on an old version of the Minitest name https://github.com/freerange/mocha/commit/32ef48f410189bb26abe574218306b612fc4de89, which was deprecated but is now removed completely, so without this update anything that updates minitest will break the test suite.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


