### PR TITLE
Move to GSS instead of SNAC, while still allowing SNAC input and existing data.

### DIFF
--- a/app/controllers/admin/places_controller.rb
+++ b/app/controllers/admin/places_controller.rb
@@ -57,7 +57,7 @@ protected
         :postcode,
         :override_lng,
         :override_lat,
-        :snac,
+        :gss,
         :url,
         :email,
         :phone,

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -127,7 +127,7 @@ class Place < ApplicationRecord
       fax: row["fax"],
       text_phone: row["text_phone"],
       source_address: row["source_address"] || "#{row['address1']} #{row['address2']} #{row['town']} #{row['postcode']}",
-      snac: row["snac"],
+      snac: row["gss"] || row["snac"],
     }
     location_parameters = if row["lng"] && row["lat"]
                             { override_lng: row["lng"], override_lat: row["lat"] }

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -18,7 +18,7 @@ class Place < ApplicationRecord
   scope :geocoded, -> { where(:location.with_size => 2) }
   default_scope -> { order(name: :asc) }
 
-  scope :missing_snacs, -> { where(snac: nil) }
+  scope :missing_gss_codes, -> { where(gss: nil) }
 
   validates :service_slug, presence: true
   validates :data_set_version, presence: true
@@ -127,7 +127,7 @@ class Place < ApplicationRecord
       fax: row["fax"],
       text_phone: row["text_phone"],
       source_address: row["source_address"] || "#{row['address1']} #{row['address2']} #{row['town']} #{row['postcode']}",
-      snac: row["gss"] || row["snac"],
+      gss: row["gss"] || row["snac"],
     }
     location_parameters = if row["lng"] && row["lat"]
                             { override_lng: row["lng"], override_lat: row["lat"] }

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -142,7 +142,7 @@ class Place < ApplicationRecord
   end
 
   def api_safe_hash
-    serializable_hash(except: :id).merge(location: location_to_hash)
+    serializable_hash(except: %i[id gss]).merge("location" => location_to_hash, "snac" => gss)
   end
 
   def location_to_hash

--- a/app/views/admin/data_sets/_file_help.html.erb
+++ b/app/views/admin/data_sets/_file_help.html.erb
@@ -8,7 +8,7 @@
 These columns will be imported (any others will be ignored):
 </p>
 <blockquote>
-  <strong>name</strong> | <strong>source_address</strong> | <strong>address1</strong> | <strong>address2</strong> | <strong>town</strong> | <strong>postcode</strong> | <strong>access_notes</strong> | <strong>general_notes</strong> | <strong>url</strong> | <strong>email</strong> | <strong>phone</strong> | <strong>fax</strong> | <strong>text_phone</strong> | <strong>snac</strong> | <strong>lng</strong> | <strong>lat</strong>
+  <strong>name</strong> | <strong>source_address</strong> | <strong>address1</strong> | <strong>address2</strong> | <strong>town</strong> | <strong>postcode</strong> | <strong>access_notes</strong> | <strong>general_notes</strong> | <strong>url</strong> | <strong>email</strong> | <strong>phone</strong> | <strong>fax</strong> | <strong>text_phone</strong> | <strong>gss</strong> | <strong>lng</strong> | <strong>lat</strong>
 </blockquote>
 <p class="lead normal">
 Use <strong>lng</strong> and <strong>lat</strong> to override the location for a place instead of using the postcode's location.

--- a/app/views/admin/data_sets/_status.html.erb
+++ b/app/views/admin/data_sets/_status.html.erb
@@ -4,6 +4,6 @@
   <%= dataset.places.with_geocoding_errors.count %> places with geocode errors.
 
   <% if service.uses_local_authority_lookup? %>
-    <%= dataset.places.missing_snacs.count %> places with missing SNAC codes.
+    <%= dataset.places.missing_gss_codes.count %> places with missing GSS codes.
   <% end %>
 </p>

--- a/app/views/admin/places/_form.html.erb
+++ b/app/views/admin/places/_form.html.erb
@@ -86,10 +86,10 @@
 
     <div class="form-group">
       <span class="form-label">
-        <%= f.label :snac, "SNAC code" %>
+        <%= f.label :gss, "GSS code" %>
       </span>
       <span class="form-wrapper">
-        <%= f.text_field :snac, class: 'input-md-2 form-control' %>
+        <%= f.text_field :gss, class: 'input-md-2 form-control' %>
       </span>
     </div>
   </fieldset>

--- a/app/views/admin/services/_history.html.erb
+++ b/app/views/admin/services/_history.html.erb
@@ -26,9 +26,9 @@
           <p class="alert alert-warning">No places are associated with this set. The imported data could be in the wrong format.</p>
         <% end %>
 
-        <% if set.has_places_with_missing_snacs? %>
-          <p class="alert alert-warning missing-snac-warning">
-            This Service uses 'Local authority' as location match type and this dataset contains places that are missing SNAC codes.
+        <% if set.has_places_with_missing_gss_codes? %>
+          <p class="alert alert-warning missing-gss-warning">
+            This Service uses 'Local authority' as location match type and this dataset contains places that are missing GSS codes.
           </p>
         <% end %>
 

--- a/db/migrate/20231009093208_alter_places_change_snac_to_gss.rb
+++ b/db/migrate/20231009093208_alter_places_change_snac_to_gss.rb
@@ -1,0 +1,6 @@
+class AlterPlacesChangeSnacToGss < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :place_archives, :snac, :gss
+    rename_column :places, :snac, :gss
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_10_091714) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_09_093208) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -68,7 +68,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_10_091714) do
     t.float "override_lat"
     t.float "override_lng"
     t.string "geocode_error"
-    t.string "snac"
+    t.string "gss"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -93,7 +93,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_10_091714) do
     t.float "override_lat"
     t.float "override_lng"
     t.string "geocode_error"
-    t.string "snac"
+    t.string "gss"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["service_slug", "data_set_version"], name: "index_places_on_service_slug_and_data_set_version"

--- a/features/data_sets.feature
+++ b/features/data_sets.feature
@@ -129,3 +129,17 @@ Feature: Managing data sets
       And I go to the page for the "Register Offices" service
 
     Then I should see that the current service has 2 missing GSS codes
+
+Scenario: Creating a new data set for a service with local authority lookup with a CSV file with SNAC codes
+    Given I have previously created a service with the following attributes:
+        | name                | Register Offices |
+        | location_match_type | Local authority  |
+
+    When I go to the page for the "Register Offices" service
+      And I upload a new data set with a CSV with a SNAC column instead of GSS
+
+    When background processing has completed
+      And I activate the most recent data set for the "Register Offices" service
+      And I go to the page for the "Register Offices" service
+
+    Then I should see that the current service has 0 missing GSS codes

--- a/features/data_sets.feature
+++ b/features/data_sets.feature
@@ -116,16 +116,16 @@ Feature: Managing data sets
     Then the "Council tax valuation offices" service should have two data sets
       And the places should be identical between the datasets in the "Council tax valuation offices" service
 
-  Scenario: Creating a new data set for a service with local authority lookup with a CSV file with SNAC codes
+  Scenario: Creating a new data set for a service with local authority lookup with a CSV file with GSS codes
     Given I have previously created a service with the following attributes:
         | name                | Register Offices |
         | location_match_type | Local authority  |
 
     When I go to the page for the "Register Offices" service
-      And I upload a new data set with a CSV with missing SNAC codes
+      And I upload a new data set with a CSV with missing GSS codes
 
     When background processing has completed
       And I activate the most recent data set for the "Register Offices" service
       And I go to the page for the "Register Offices" service
 
-    Then I should see that the current service has 2 missing SNAC codes
+    Then I should see that the current service has 2 missing GSS codes

--- a/features/services.feature
+++ b/features/services.feature
@@ -59,30 +59,30 @@ Feature: Managing services
     Then I should see an indication that my file was not accepted
       And there should not be a "Register Offices" service
 
-  Scenario: Creating a new service with local authority lookup with a file with missing snac codes
+  Scenario: Creating a new service with local authority lookup with a file with missing GSS codes
     When I go to the new service page
       And I fill out the form with the following attributes to create a service:
-        | name                | Register Offices With Missing Snac Codes |
+        | name                | Register Offices With Missing GSS Codes |
         | location_match_type | Local authority                          |
 
     When background processing has completed
-      And I go to the page for the "Register Offices With Missing Snac Codes" service
+      And I go to the page for the "Register Offices With Missing GSS Codes" service
 
-    Then I should see that the current service has 2 missing SNAC codes
+    Then I should see that the current service has 2 missing GSS codes
 
     When I visit the history tab
 
     Then the first version panel has the title "Version 1"
-      And the first version panel has the text "2 places with missing SNAC codes"
-      And the first version panel shows a warning about missing SNAC codes
+      And the first version panel has the text "2 places with missing GSS codes"
+      And the first version panel shows a warning about missing GSS codes
 
-  Scenario: Creating a new service with nearest lookup with a file with missing snac codes
+  Scenario: Creating a new service with nearest lookup with a file with missing GSS codes
     When I go to the new service page
       And I fill out the form with the following attributes to create a service:
-        | name                | Register Offices With Missing Snac Codes |
+        | name                | Register Offices With Missing GSS Codes |
         | location_match_type | Nearest                                  |
 
     When background processing has completed
-      And I go to the page for the "Register Offices With Missing Snac Codes" service
+      And I go to the page for the "Register Offices With Missing GSS Codes" service
 
-    Then I should not see any text about missing SNAC codes
+    Then I should not see any text about missing GSS codes

--- a/features/step_definitions/data_set_steps.rb
+++ b/features/step_definitions/data_set_steps.rb
@@ -27,6 +27,13 @@ When(/^I upload a new data set with a PNG claiming to be a CSV$/) do
   end
 end
 
+When(/^I upload a new data set with a CSV with a SNAC column instead of GSS$/) do
+  within "#new-data" do
+    attach_file "Data file", Rails.root.join("features/support/data/register-offices-with-snac-codes.csv")
+    click_button "Create Data set"
+  end
+end
+
 When(/^I upload a new data set with a CSV with missing GSS codes$/) do
   within "#new-data" do
     attach_file "Data file", Rails.root.join("features/support/data/register-offices-with-missing-gss-codes.csv")

--- a/features/step_definitions/data_set_steps.rb
+++ b/features/step_definitions/data_set_steps.rb
@@ -27,9 +27,9 @@ When(/^I upload a new data set with a PNG claiming to be a CSV$/) do
   end
 end
 
-When(/^I upload a new data set with a CSV with missing SNAC codes$/) do
+When(/^I upload a new data set with a CSV with missing GSS codes$/) do
   within "#new-data" do
-    attach_file "Data file", Rails.root.join("features/support/data/register-offices-with-missing-snac-codes.csv")
+    attach_file "Data file", Rails.root.join("features/support/data/register-offices-with-missing-gss-codes.csv")
     click_button "Create Data set"
   end
 end

--- a/features/step_definitions/service_steps.rb
+++ b/features/step_definitions/service_steps.rb
@@ -83,13 +83,13 @@ Then(/^there should not be a "(.*?)" service$/) do |name|
   expect(Service.where(name:).count).to eq(0)
 end
 
-Then(/^I should see that the current service has (\d+) missing SNAC codes$/) do |count|
-  content = "#{count} places with missing SNAC codes."
+Then(/^I should see that the current service has (\d+) missing GSS codes$/) do |count|
+  content = "#{count} places with missing GSS codes."
   expect(page).to have_content(content)
 end
 
-Then(/^I should not see any text about missing SNAC codes$/) do
-  expect(page).to_not have_content("places with missing SNAC codes.")
+Then(/^I should not see any text about missing GSS codes$/) do
+  expect(page).to_not have_content("places with missing GSS codes.")
 end
 
 When(/^I activate the most recent data set for the "(.*?)" service$/) do |name|
@@ -119,8 +119,8 @@ Then(/^the first version panel has the text "(.*?)"$/) do |text|
   end
 end
 
-Then(/^the first version panel shows a warning about missing SNAC codes$/) do
+Then(/^the first version panel shows a warning about missing GSS codes$/) do
   within "div.data-set:nth-child(1)" do
-    expect(page).to have_css("p.missing-snac-warning")
+    expect(page).to have_css("p.missing-gss-warning")
   end
 end

--- a/features/support/data/council-tax-valuation-offices.csv
+++ b/features/support/data/council-tax-valuation-offices.csv
@@ -1,2 +1,2 @@
-service_slug,data_set_version,name,source_address,address1,address2,town,postcode,access_notes,general_notes,url,email,phone,fax,text_phone,geocode_error,snac,lng,lat
+service_slug,data_set_version,name,source_address,address1,address2,town,postcode,access_notes,general_notes,url,email,phone,fax,text_phone,geocode_error,gss,lng,lat
 council-tax-valuation-offices,1,Fife Council,Fife House (03) North Street Glenrothes KY7 5LY,Fife House (03),North Street,Glenrothes,KY7 5LY,Access note,General note,www.example.com,fife@example.com,01592 414141,01592 413194,01592 413195,,00QR,-3.17575,56.19755

--- a/features/support/data/register-offices-with-missing-gss-codes.csv
+++ b/features/support/data/register-offices-with-missing-gss-codes.csv
@@ -1,4 +1,4 @@
-name,address1,address2,town,postcode,access_notes,general_notes,url,lat,lng,phone,fax,text_phone,snac
-Town Hall,Cauldwell Street,Bedford,,MK42 9AP,,,http://www.bedford.gov.uk/advice_and_benefits/registration_service.aspx,52.1327584352089,-0.4702813074674147,,,,00KB
+name,address1,address2,town,postcode,access_notes,general_notes,url,lat,lng,phone,fax,text_phone,gss
+Town Hall,Cauldwell Street,Bedford,,MK42 9AP,,,http://www.bedford.gov.uk/advice_and_benefits/registration_service.aspx,52.1327584352089,-0.4702813074674147,,,,E06000002
 County Hall,Walton Street,Aylesbury,,HP20 1XF,,,http://www.buckscc.gov.uk/registration/index.stm,51.81525988351161,-0.8119554673823927,,,,
 Shire Hall,Castle Hill,Cambridge,,CB3 0AP,,,http://www.cambridgeshire.gov.uk/community/bmd/,52.2128132777458,0.11402791296760088,,,,

--- a/features/support/data/register-offices-with-snac-codes.csv
+++ b/features/support/data/register-offices-with-snac-codes.csv
@@ -1,0 +1,4 @@
+name,address1,address2,town,postcode,access_notes,general_notes,url,lat,lng,phone,fax,text_phone,snac
+Town Hall,Cauldwell Street,Bedford,,MK42 9AP,,,http://www.bedford.gov.uk/advice_and_benefits/registration_service.aspx,52.1327584352089,-0.4702813074674147,,,,00KB
+County Hall,Walton Street,Aylesbury,,HP20 1XF,,,http://www.buckscc.gov.uk/registration/index.stm,51.81525988351161,-0.8119554673823927,,,,00KB
+Shire Hall,Castle Hill,Cambridge,,CB3 0AP,,,http://www.cambridgeshire.gov.uk/community/bmd/,52.2128132777458,0.11402791296760088,,,,00KB

--- a/test/integration/places_api_test.rb
+++ b/test/integration/places_api_test.rb
@@ -164,7 +164,7 @@ class PlacesAPITest < ActionDispatch::IntegrationTest
         @place1 = FactoryBot.create(
           :place,
           service_slug: @service.slug,
-          snac: "18UK",
+          gss: "18UK",
           latitude: 51.0519276,
           longitude: -4.1907002,
           name: "John's Of Appledore",
@@ -172,7 +172,7 @@ class PlacesAPITest < ActionDispatch::IntegrationTest
         @place2 = FactoryBot.create(
           :place,
           service_slug: @service.slug,
-          snac: "18UK",
+          gss: "18UK",
           latitude: 51.053834,
           longitude: -4.191422,
           name: "Susie's Tea Rooms",
@@ -180,7 +180,7 @@ class PlacesAPITest < ActionDispatch::IntegrationTest
         @place3 = FactoryBot.create(
           :place,
           service_slug: @service.slug,
-          snac: "00AG",
+          gss: "00AG",
           latitude: 51.500728,
           longitude: -0.124626,
           name: "Palace of Westminster",
@@ -188,7 +188,7 @@ class PlacesAPITest < ActionDispatch::IntegrationTest
         @place4 = FactoryBot.create(
           :place,
           service_slug: @service.slug,
-          snac: "00AG",
+          gss: "00AG",
           latitude: 51.51837458322272,
           longitude: -0.12133586354538765,
           name: "FreeState Coffee",
@@ -196,7 +196,7 @@ class PlacesAPITest < ActionDispatch::IntegrationTest
         @place5 = FactoryBot.create(
           :place,
           service_slug: @service.slug,
-          snac: "18",
+          gss: "18",
           latitude: 51.05420,
           longitude: -4.19096,
           name: "The Coffee Cabin",
@@ -204,7 +204,7 @@ class PlacesAPITest < ActionDispatch::IntegrationTest
         @place6 = FactoryBot.create(
           :place,
           service_slug: @service.slug,
-          snac: "18",
+          gss: "18",
           latitude: 51.05289,
           longitude: -4.19111,
           name: "The Quay Restaurant and Gallery",
@@ -212,7 +212,7 @@ class PlacesAPITest < ActionDispatch::IntegrationTest
         @place7 = FactoryBot.create(
           :place,
           service_slug: @service.slug,
-          snac: "E060000063",
+          gss: "E060000063",
           latitude: 51.05420,
           longitude: -4.19096,
           name: "Cumbrian Cabin",
@@ -220,7 +220,7 @@ class PlacesAPITest < ActionDispatch::IntegrationTest
         @place8 = FactoryBot.create(
           :place,
           service_slug: @service.slug,
-          snac: "E060000063",
+          gss: "E060000063",
           latitude: 51.05289,
           longitude: -4.19111,
           name: "Cumbrian Gallery",

--- a/test/unit/data_set_test.rb
+++ b/test/unit/data_set_test.rb
@@ -450,7 +450,7 @@ class DataSetTest < ActiveSupport::TestCase
         @place1 = FactoryBot.create(
           :place,
           service_slug: @service.slug,
-          snac: "18UK",
+          gss: "18UK",
           postcode: "EX39 1QS",
           latitude: 51.05318361810428,
           longitude: -4.191071523498792,
@@ -459,7 +459,7 @@ class DataSetTest < ActiveSupport::TestCase
         @place2 = FactoryBot.create(
           :place,
           service_slug: @service.slug,
-          snac: "E12345678",
+          gss: "E12345678",
           postcode: "EX39 1PP",
           latitude: 51.053834,
           longitude: -4.191422,
@@ -468,7 +468,7 @@ class DataSetTest < ActiveSupport::TestCase
         @place3 = FactoryBot.create(
           :place,
           service_slug: @service.slug,
-          snac: "00AG",
+          gss: "00AG",
           postcode: "WC2B 6NH",
           latitude: 51.51695975170424,
           longitude: -0.12058693935709164,
@@ -477,7 +477,7 @@ class DataSetTest < ActiveSupport::TestCase
         @place4 = FactoryBot.create(
           :place,
           service_slug: @service.slug,
-          snac: "00AG",
+          gss: "00AG",
           postcode: "WC1B 5HA",
           latitude: 51.51837458322272,
           longitude: -0.12133586354538765,

--- a/test/unit/presenters/data_set_csv_presenter_test.rb
+++ b/test/unit/presenters/data_set_csv_presenter_test.rb
@@ -27,7 +27,7 @@ class DataSetCsvPresenterTest < ActiveSupport::TestCase
       fax
       text_phone
       geocode_error
-      snac
+      gss
       lng
       lat
     ]
@@ -46,7 +46,7 @@ class DataSetCsvPresenterTest < ActiveSupport::TestCase
         service_slug: @service.slug,
         data_set_version: @data_set.version,
         email: "camden@example.com",
-        snac: "00AG",
+        gss: "00AG",
         override_lng: 0.0,
         override_lat: 1.0,
       )
@@ -71,7 +71,7 @@ class DataSetCsvPresenterTest < ActiveSupport::TestCase
         @place.fax,
         @place.text_phone,
         @place.geocode_error,
-        @place.snac,
+        @place.gss,
         @place.override_lng,
         @place.override_lat,
       ]


### PR DESCRIPTION
SNAC codes have been deprecated for quite a while, and there are a number of new Local Authorities that don't have SNAC codes at all. This update renames the database columns, replaces front-end references to SNAC with GSS, and allows data files to have a gss column instead of a SNAC column. The column is already able to accept gss codes in the snac column, so it's just the name of the column that's changed. Existing datafiles don't need to be updated because it will for the moment still accept snac as a column heading, but downloaded CSV versions of existing datafiles will have the gss column header.

Remaining unchanged:
- API Interfaces referencing SNAC (ie json output)
  
This is the first step in swapping over to exclusively gss codes in Imminence.


https://trello.com/c/p1sNfXR4/2214-allow-snac-column-in-imminence-imports-to-be-called-gss

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
