### PR TITLE
Allow mixed SNAC/GSS Searches

### DIFF
--- a/app/models/data_set.rb
+++ b/app/models/data_set.rb
@@ -39,14 +39,14 @@ class DataSet < ApplicationRecord
   #   location - a Point object representing the centre of the search area
   #   distance (optional) - a Distance object representing the maximum distance
   #   limit (optional) - a maximum number of results to return
-  #   authority_code (optional) - a SNAC/GSS code to scope the results to a local authority
+  #   authority_codes (optional) - array of SNAC/GSS code to scope the results to a local authority
   #
   # Returns:
   #   an array of Place objects
-  def places_near(location, distance = nil, limit = nil, authority_code = nil)
+  def places_near(location, distance = nil, limit = nil, authority_codes = [])
     loc_string = "'SRID=4326;POINT(#{location.longitude} #{location.latitude})'::geometry"
     query = places
-    query = query.where(snac: authority_code) if authority_code
+    query = query.where(snac: authority_codes) if authority_codes.any?
     query = query.limit(limit) if limit
     query = query.where(Place.arel_table[:location].st_distance(location).lt(distance.in(:meters))) if distance
     query = query.reorder(Arel.sql("location <-> #{loc_string}, RANDOM()"))
@@ -60,24 +60,24 @@ class DataSet < ApplicationRecord
     location = RGeo::Geographic.spherical_factory.point(location_data["longitude"], location_data["latitude"])
     return places_near(location, distance, limit) if service.location_match_type == "nearest"
 
-    authority_code = if local_authority_slug
-                       authority_code_for_local_authority_slug(local_authority_slug)
-                     else
-                       appropriate_authority_code_for_postcode(postcode)
-                     end
-    return [] unless authority_code
+    authority_codes = if local_authority_slug
+                        authority_codes_for_local_authority_slug(local_authority_slug)
+                      else
+                        appropriate_authority_codes_for_postcode(postcode)
+                      end
+    return [] unless authority_codes
 
-    places_near(location, distance, limit, authority_code)
+    places_near(location, distance, limit, authority_codes)
   end
 
-  def authority_code_for_local_authority_slug(local_authority_slug)
+  def authority_codes_for_local_authority_slug(local_authority_slug)
     local_authorities_response = GdsApi.local_links_manager.local_authority(local_authority_slug)
 
     local_authority = local_authorities_response.to_hash["local_authorities"].find do |la|
       [service.local_authority_hierarchy_match_type, "unitary"].include?(la["tier"])
     end
 
-    snac_or_gss(local_authority)
+    snac_and_gss(local_authority)
   end
 
   def appropriate_authority_for_local_custodian_code(local_custodian_code)
@@ -87,7 +87,7 @@ class DataSet < ApplicationRecord
     end
   end
 
-  def appropriate_authority_code_for_postcode(postcode)
+  def appropriate_authority_codes_for_postcode(postcode)
     local_custodian_codes = GdsApi.locations_api.local_custodian_code_for_postcode(postcode)
     return nil if local_custodian_codes.compact.empty?
 
@@ -106,17 +106,17 @@ class DataSet < ApplicationRecord
     end
 
     authority_hash = appropriate_authority_for_local_custodian_code(local_custodian_codes.first) # there should be 0-1, return first or nil
-    snac_or_gss(authority_hash)
+    snac_and_gss(authority_hash)
   rescue GdsApi::HTTPNotFound
     nil
   end
 
-  def snac_or_gss(authority_hash)
-    # Not all LAs have SNACs now, so we return nil if the authority hash is nil,
-    # or the SNAC if there is one, or the GSS if there isn't a SNAC
-    return unless authority_hash
+  def snac_and_gss(authority_hash)
+    # Not all LAs have SNACs now, so we return an array including
+    # SNAC and GSS (or whichever they have)
+    return [] unless authority_hash
 
-    authority_hash.key?("snac") ? authority_hash["snac"] : authority_hash["gss"]
+    [authority_hash["snac"], authority_hash["gss"]].compact
   end
 
   def duplicating?

--- a/test/unit/data_set_test.rb
+++ b/test/unit/data_set_test.rb
@@ -459,7 +459,7 @@ class DataSetTest < ActiveSupport::TestCase
         @place2 = FactoryBot.create(
           :place,
           service_slug: @service.slug,
-          snac: "18UK",
+          snac: "E12345678",
           postcode: "EX39 1PP",
           latitude: 51.053834,
           longitude: -4.191422,
@@ -485,9 +485,9 @@ class DataSetTest < ActiveSupport::TestCase
         )
       end
 
-      should "return places in the same district as the postcode" do
+      should "return places in the same district/unitary authority as the postcode, matching by GSS or SNAC" do
         stub_locations_api_has_location("EX39 1LH", [{ "latitude" => 51.0413792674, "longitude" => -4.23640704632, "local_custodian_code" => 1234 }])
-        stub_local_links_manager_has_a_local_authority("county1", country_name: "England", snac: "18UK", local_custodian_code: 1234)
+        stub_local_links_manager_has_a_local_authority("county1", country_name: "England", gss: "E12345678", snac: "18UK", local_custodian_code: 1234)
         place_names = @data_set.places_for_postcode("EX39 1LH").map(&:name)
         assert_equal ["John's Of Appledore", "Susie's Tea Rooms"], place_names
       end
@@ -500,7 +500,7 @@ class DataSetTest < ActiveSupport::TestCase
         assert_equal ["Aviation House", "FreeState Coffee"], place_names
       end
 
-      should "return empty array if no SNAC can be found for the postcode" do
+      should "return empty array if no SNAC/GSS can be found for the postcode" do
         stub_locations_api_has_location("BT1 5GS", [{ "latitude" => 21.54, "longitude" => -5.93 }])
 
         assert_equal [], @data_set.places_for_postcode("BT1 5GS").to_a


### PR DESCRIPTION
Allows searching by both the GSS and SNAC for a local authority (previously it would default to searching by SNAC and only search by GSS if SNAC didn't exist). This will prevent searches stopping working while we transition imminence datasets to GSS only.

https://trello.com/c/gzPXvFIT/2213-allow-imminence-to-find-by-both-snac-and-gss

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
