### PR TITLE
Add GitHub Actions to dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: /
     schedule:
       interval: daily
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
This adds GitHub Actions dependencies into dependabot.  The resulting PRs that dependabot will raise are needed to satisfy the testing requirements in https://github.com/alphagov/gds-api-adapters/pull/1221.