### PR TITLE
Use dummy base secret key for precompiling assets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY Gemfile* .ruby-version ./
 RUN bundle install
 COPY . .
 RUN bootsnap precompile --gemfile .
-RUN rails assets:precompile && rm -fr log
+RUN SECRET_KEY_BASE_DUMMY=1 rails assets:precompile && rm -fr log
 
 
 FROM $base_image


### PR DESCRIPTION
As per https://guides.rubyonrails.org/asset_pipeline.html#local-precompilation, we can use a randomly generated secret key base stored in a temporary file to precompile assets.

The Docker image build does not need access to production secrets.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
