### PR TITLE
Remove unused launchy gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,6 @@ group :test do
   gem "cucumber-rails", require: false
   gem "factory_bot_rails"
   gem "govuk_test"
-  gem "launchy"
   gem "minitest-reporters"
   gem "mocha", require: false
   gem "rails-controller-testing"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -266,8 +266,6 @@ GEM
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
     language_server-protocol (3.17.0.3)
-    launchy (2.5.2)
-      addressable (~> 2.8)
     link_header (0.0.8)
     logstasher (2.1.5)
       activesupport (>= 5.2)
@@ -811,7 +809,6 @@ DEPENDENCIES
   govuk_test
   inherited_resources
   kaminari
-  launchy
   minitest-reporters
   mocha
   pact


### PR DESCRIPTION
We don't actually use this gem, so remove it from gemfile/lock

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
