### PR TITLE
Import public urls

### DIFF
--- a/db/migrate/20240305134247_add_govuk_url_and_govuk_title_to_services.rb
+++ b/db/migrate/20240305134247_add_govuk_url_and_govuk_title_to_services.rb
@@ -1,0 +1,8 @@
+class AddGovukUrlAndGovukTitleToServices < ActiveRecord::Migration[7.1]
+  def change
+    change_table(:services, bulk: true) do |t|
+      t.column :govuk_url, :string
+      t.column :govuk_title, :string
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_09_093208) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_05_134247) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -108,6 +108,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_09_093208) do
     t.string "local_authority_hierarchy_match_type", default: "district"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "govuk_url"
+    t.string "govuk_title"
     t.index ["slug"], name: "index_services_on_slug", unique: true
   end
 

--- a/lib/tasks/service_urls_from_govuk.rake
+++ b/lib/tasks/service_urls_from_govuk.rake
@@ -1,0 +1,19 @@
+desc "Updates Service records with titles/links to the GOV.UK place documents"
+task service_urls_from_govuk: :environment do
+  content_store_api = GdsApi.content_store
+  place_pages = GdsApi.search.search({ filter_format: "place", count: 200, fields: "title,link,content_id" })
+
+  place_pages["results"].each do |pp|
+    ci = content_store_api.content_item(pp["link"])
+    slug =  ci.to_hash["details"]["place_type"]
+    service = Service.where(slug:).first
+    if service
+      Rails.logger.info("Adding #{pp['title']} to #{slug}")
+      service.govuk_url = pp["link"]
+      service.govuk_title = pp["title"]
+      service.save!
+    else
+      Rails.logger.warn("Service slug #{slug} referenced in path #{pp['link']} does not exist!")
+    end
+  end
+end


### PR DESCRIPTION
Adds govuk_url and govuk_title columns to services, and a rake task that will populate them from the content store so that in later tasks we can audit the services that are still being used, and potentially display the govuk.page to the user.

https://trello.com/c/bMqXRZ53/2395-add-govuk-pages-to-imminence-services

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
