### PR TITLE
Dynamic lookup and display of frontend pages that reference services

### DIFF
--- a/app/services/govuk_site_lookup_service.rb
+++ b/app/services/govuk_site_lookup_service.rb
@@ -1,0 +1,26 @@
+class GovukSiteLookupService
+  def govuk_page?(slug)
+    public_url_info.key?(slug)
+  end
+
+  def page_link(slug)
+    public_url_info[slug][:link]
+  end
+
+  def page_title(slug)
+    public_url_info[slug][:title]
+  end
+
+  def public_url_info
+    Rails.cache.fetch("imminence_public_url_info", expires_in: 5.minutes) do
+      content_store_api = GdsApi.content_store
+      place_pages = GdsApi.search.search({ filter_format: "place", count: 200, fields: "title,link" })
+
+      place_pages["results"].each_with_object({}) do |pp, hash|
+        ci = content_store_api.content_item(pp["link"])
+        slug = ci["details"]["place_type"]
+        hash[slug] = { link: Plek.website_root + pp["link"], title: pp["title"] }
+      end
+    end
+  end
+end

--- a/app/views/admin/services/_service.html.erb
+++ b/app/views/admin/services/_service.html.erb
@@ -5,6 +5,13 @@
     <% end %>
   </td>
   <td>
+    <% if lookup.govuk_page?(service.slug) %>
+      <%= link_to(lookup.page_title(service.slug), lookup.page_link(service.slug)) %>
+    <% else %>
+      Not present on GOV.UK
+    <% end %>
+  </td>
+  <td>
     <%= pluralize(number_with_delimiter(service.data_sets.count), "data set", "data sets") %>
   </td>
   <td>

--- a/app/views/admin/services/index.html.erb
+++ b/app/views/admin/services/index.html.erb
@@ -11,6 +11,7 @@
   <thead>
     <tr class="table-header">
       <th scope="col">Service</th>
+      <th scope="col">GOV.UK page</th>
       <th scope="col">Data sets</th>
       <th scope="col">Places</th>
     </tr>
@@ -24,6 +25,6 @@
     </tr>
   </thead>
   <tbody>
-    <%= render :collection => @services, :partial => "service", :locals => {:tab => :drafts} %>
+    <%= render collection: @services, partial: "service", locals: { tab: :drafts, lookup: GovukSiteLookupService.new } %>
   </tbody>
 </table>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -28,7 +28,7 @@ Rails.application.configure do
   config.cache_store = :null_store
 
   # Raise exceptions instead of rendering exception templates.
-  config.action_dispatch.show_exceptions = false
+  config.action_dispatch.show_exceptions = :none
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false

--- a/test/integration/places_api_test.rb
+++ b/test/integration/places_api_test.rb
@@ -76,6 +76,10 @@ class PlacesAPITest < ActionDispatch::IntegrationTest
     end
 
     context "requesting a specific version" do
+      setup do
+        stub_request(:get, "http://search-api.dev.gov.uk/search.json?count=200&fields=title,link&filter_format=place").to_return(status: 200, body: { results: [] }.to_json, headers: {})
+      end
+
       should "return requested version when logged in" do
         GDS::SSO.test_user = FactoryBot.create(:user)
         visit "/admin" # necessary to setup the login session

--- a/test/unit/services/govuk_site_lookup_service_test.rb
+++ b/test/unit/services/govuk_site_lookup_service_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+
+class GovukSiteLookupServiceTest < ActiveSupport::TestCase
+  setup do
+    search_results = {
+      results: [
+        { title: "Test Service", link: "/test-service-page" },
+      ],
+    }
+    stub_request(:get, "http://search-api.dev.gov.uk/search.json?count=200&fields=title,link&filter_format=place")
+      .to_return(status: 200, body: search_results.to_json, headers: {})
+
+    content_item = {
+      details: {
+        place_type: "test-service",
+      },
+    }
+    stub_request(:get, "http://content-store.dev.gov.uk/content/test-service-page")
+      .to_return(status: 200, body: content_item.to_json, headers: {})
+  end
+
+  test "#govuk_page? returns true if page in search" do
+    assert_equal(true, GovukSiteLookupService.new.govuk_page?("test-service"))
+  end
+  test "#govuk_page? returns false if page in search" do
+    assert_equal(false, GovukSiteLookupService.new.govuk_page?("missing-service"))
+  end
+
+  test "#page_link returns full url of frontend page" do
+    assert_equal("http://www.dev.gov.uk/test-service-page", GovukSiteLookupService.new.page_link("test-service"))
+  end
+
+  test "#page_title returns title of frontend page" do
+    assert_equal("Test Service", GovukSiteLookupService.new.page_title("test-service"))
+  end
+end


### PR DESCRIPTION
Quality of Life for users - adds cached retrieval of data about the frontend pages that use imminence services so that the list of services can show the actual URL where the service appears on gov.uk.

https://trello.com/c/bMqXRZ53/2395-add-govuk-pages-to-imminence-services

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
