### PR TITLE
Add organisation slug to service summary

### DIFF
--- a/app/presenters/service_presenter.rb
+++ b/app/presenters/service_presenter.rb
@@ -8,6 +8,7 @@ class ServicePresenter
   def summary_list(view_context)
     summary_items = [
       { field: "Slug", value: @service.slug },
+      { field: "Organisation Slugs", value: @service.organisation_slugs.join("<br />".html_safe) },
       { field: "GOV.UK page", value: page_link(view_context) },
       { field: "Source of data", value: @service.source_of_data },
       { field: "Location match type", value: match_type },


### PR DESCRIPTION
Reskin missed showing the organisation slugs on the summary page

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
