### PR TITLE
Fix incorrect positioning of html_safe

### DIFF
--- a/app/presenters/service_presenter.rb
+++ b/app/presenters/service_presenter.rb
@@ -8,7 +8,7 @@ class ServicePresenter
   def summary_list(view_context)
     summary_items = [
       { field: "Slug", value: @service.slug },
-      { field: "Organisation Slugs", value: @service.organisation_slugs.join("<br />".html_safe) },
+      { field: "Organisation Slugs", value: @service.organisation_slugs.join("<br />").html_safe },
       { field: "GOV.UK page", value: page_link(view_context) },
       { field: "Source of data", value: @service.source_of_data },
       { field: "Location match type", value: match_type },


### PR DESCRIPTION
Bracket in the wrong place meant that html tags were appearing in the service summary organisational slugs field rather than the slugs being formatted.

## Before
<img width="771" alt="Screenshot 2024-04-10 at 09 33 32" src="https://github.com/alphagov/imminence/assets/4225737/77522271-c41b-409a-99ff-00badce2a90d">

## After
<img width="788" alt="Screenshot 2024-04-10 at 09 37 38" src="https://github.com/alphagov/imminence/assets/4225737/0f26c734-c082-461d-8300-8e68e404533d">

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
