### PR TITLE
Add permissions to Brakeman job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,11 @@ jobs:
   security-analysis:
     name: Security Analysis
     uses: alphagov/govuk-infrastructure/.github/workflows/brakeman.yml@main
+    secrets: inherit
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
 
   lint-ruby:
     name: Lint Ruby


### PR DESCRIPTION
Adds permissions for Brakeman workflow to upload findings to GitHub Code Scanning within this repository. This will enhance visibility within GitHub UI, with findings displayed similarly to CodeQL. An example can be viewed [here](https://github.com/alphagov/support-api/pull/932). 

This PR will be reviewed and merged by the Platform Security and Reliability team. Any questions or concerns, please reach out in our channel: #govuk-platform-security-reliability-team.

GOV.UK Infrastructure PR dependent on this: [Link](https://github.com/alphagov/govuk-infrastructure/pull/1238).

[Trello card](https://trello.com/c/AFw2LOkY/3457-integrate-brakeman-findings-with-github-code-scanning-5)