### PR TITLE
Add list to work out what artifacts are being downloaded

### DIFF
--- a/.github/workflows/pact-verify.yml
+++ b/.github/workflows/pact-verify.yml
@@ -66,4 +66,6 @@ jobs:
           name: ${{ inputs.pact_artifact }}
           path: tmp/pacts
       - if: inputs.pact_artifact != ''
+        run: ls -la tmp/pacts/
+      - if: inputs.pact_artifact != ''
         run: bundle exec rake pact:verify:at[tmp/pacts/${{ inputs.pact_artifact_file_to_verify }}]


### PR DESCRIPTION
Pulling this temporarily into main should let us see in the GH action what artifacts GDS API Adapters is pulling down for the pact verification, and maybe give us a clue as to what is going wrong.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
