### PR TITLE
Rename pact provider

### DIFF
--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -29,7 +29,7 @@ def url_encode(str)
   ERB::Util.url_encode(str)
 end
 
-Pact.service_provider "PlacesManager API" do
+Pact.service_provider "Places Manager API" do
   honours_pact_with "GDS API Adapters" do
     if ENV["PACT_URI"]
       pact_uri(ENV["PACT_URI"])


### PR DESCRIPTION
Missing space in the pact provider name might be confusing GDS API Adapters

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
